### PR TITLE
Improve pr-downloader speed

### DIFF
--- a/src/Downloader/Http/HttpDownloader.cpp
+++ b/src/Downloader/Http/HttpDownloader.cpp
@@ -646,10 +646,10 @@ bool CHttpDownloader::download(std::list<IDownload*>& download,
 		FD_ZERO(&eSet);
 		int count = 0;
 		timeval t;
-		t.tv_sec = 1;
-		t.tv_usec = 0;
+		t.tv_sec = 0;
+		t.tv_usec = 10000;
 		curl_multi_fdset(curlm, &rSet, &wSet, &eSet, &count);
-		// sleep for one sec / until something happened
+		// sleep for 10ms / until something happened
 		select(count + 1, &rSet, &wSet, &eSet, &t);
 	}
 

--- a/src/Downloader/Rapid/Sdp.cpp
+++ b/src/Downloader/Rapid/Sdp.cpp
@@ -119,11 +119,6 @@ bool CSdp::download(IDownload* dl)
 	}
 	LOG_DEBUG("Sucessfully downloaded %d files: %s %s", count,
 		  shortname.c_str(), name.c_str());
-
-	if (!fileSystem->validateSDP(sdpPath)) { //FIXME: in this call only the downloaded files should be checked
-		LOG_ERROR("Validation failed");
-		return false;
-	}
 	downloaded = true;
 	dl->state = IDownload::STATE_FINISHED;
 	return true;

--- a/src/Downloader/Rapid/Sdp.cpp
+++ b/src/Downloader/Rapid/Sdp.cpp
@@ -106,19 +106,20 @@ bool CSdp::download(IDownload* dl)
 	}
 	LOG_DEBUG("%d/%d need to download %d files", i, (int)files.size(),
 		  count);
-
-	const std::string root = fileSystem->getSpringDir() + PATH_DELIMITER + "pool" + PATH_DELIMITER;
-	if (!createPoolDirs(root)) {
-		LOG_ERROR("Creating pool directories failed");
-		return false;
+	if (count > 0) {
+		const std::string root = fileSystem->getSpringDir() + PATH_DELIMITER + "pool" + PATH_DELIMITER;
+		if (!createPoolDirs(root)) {
+			LOG_ERROR("Creating pool directories failed");
+			return false;
+		}
+		if (!downloadStream()) {
+			LOG_ERROR("Couldn't download files for %s", md5.c_str());
+			fileSystem->removeFile(sdpPath);
+			return false;
+		}
+		LOG_DEBUG("Sucessfully downloaded %d files: %s %s", count,
+			  shortname.c_str(), name.c_str());
 	}
-	if (!downloadStream()) {
-		LOG_ERROR("Couldn't download files for %s", md5.c_str());
-		fileSystem->removeFile(sdpPath);
-		return false;
-	}
-	LOG_DEBUG("Sucessfully downloaded %d files: %s %s", count,
-		  shortname.c_str(), name.c_str());
 	downloaded = true;
 	dl->state = IDownload::STATE_FINISHED;
 	return true;


### PR DESCRIPTION
Two changes:
1. Removed select wait from 1s to 10ms: I've noticed that sometimes it just unnecessarily waits for 1s without progressing, maybe at some point all passed fds are already ready and select doesn't generate any notification.
2. Stop doing full validation of whole Sdp file after each update. Each file building Sdp is already verified in the [WriteData](https://github.com/beyond-all-reason/pr-downloader/blob/master/src/Downloader/Rapid/Sdp.cpp#L216).
3. Don't initialize steam download if there aren't any files to download.

About 2:

The current code will catch situation where both, at the same time:
1. File is corrupted
2. pr-downloader crashes/is killed between `SafeCloseFile` and `fileSystem->removeFile`

It's highly unlikely scenario.

The current code also catches when there is a silent on disc corruption, or there is power outage and somehow files are inconsistent. (Note that when downloading file using CFile, it's first being saved as tmp, [and only then moved to destination](https://github.com/beyond-all-reason/pr-downloader/blob/master/src/FileSystem/File.cpp#L49) so there is quite fine protection).

Given that e.g. maps/engine downloaded via HTTP don't have similar protection at all, it makes sense to drop this second consistency validation.

---

Overall savings: 1: 2-3s, 2: ~9s (from ramdisk), 3: ~100ms. 

With it:
```
time ./src/pr-downloader --filesystem-writepath /tmp/pr-downloader-test --rapid-download byar:test | tail -n 1
[Info] /home/p2004a/Workspace/BAR/pr-downloader/src/main.cpp:215:main():Download complete!
./src/pr-downloader --filesystem-writepath /tmp/pr-downloader-test  byar:test  0,09s user 0,05s system 65% cpu 0,208 total
tail -n 1  0,00s user 0,00s system 1% cpu 0,208 total
```