### PR TITLE
Improve recovery from corrupted {versions,repo}.gz files.

### DIFF
--- a/src/Downloader/Rapid/Repo.cpp
+++ b/src/Downloader/Rapid/Repo.cpp
@@ -81,15 +81,18 @@ bool CRepo::parse()
 		rapid->addRemoteSdp(CSdp { items[0], items[1], items[3], items[2], repourl });
 	}
 	int errnum = Z_OK;
+	bool ok = true;
 	const char* errstr = gzerror(fp, &errnum);
-	switch (errnum) {
-		case Z_OK:
-		case Z_STREAM_END:
-			break;
-		default:
-			LOG_ERROR("%d %s\n", errnum, errstr);
+	if (errnum != Z_OK && errnum != Z_STREAM_END) {
+		LOG_ERROR("%d %s\n", errnum, errstr);
+		ok = false;
 	}
 	gzclose(fp);
 	fclose(f);
-	return true;
+	return ok;
+}
+
+bool CRepo::deleteRepoFile()
+{
+	return fileSystem->removeFile(tmpFile);
 }

--- a/src/Downloader/Rapid/Repo.h
+++ b/src/Downloader/Rapid/Repo.h
@@ -31,6 +31,8 @@ public:
   */
 	bool parse();
 
+	bool deleteRepoFile();
+
 	const std::string& getShortName() const
 	{
 		return shortname;

--- a/src/Downloader/Rapid/Sdp.cpp
+++ b/src/Downloader/Rapid/Sdp.cpp
@@ -37,7 +37,6 @@ CSdp::CSdp(const std::string& shortname, const std::string& md5,
 		fileSystem->createSubdirs(dir);
 	}
 	sdpPath = dir + md5 + ".sdp";
-	LOG_DEBUG("%s", sdpPath.c_str());
 }
 
 CSdp::CSdp(CSdp&& sdp) = default;

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -119,11 +119,15 @@ bool search(DownloadEnum::Category cat, const char* name,
 		case DownloadEnum::CAT_GAME:
 		case DownloadEnum::CAT_COUNT:
 		case DownloadEnum::CAT_NONE:
-			rapidDownload->search(searchres, searchname.c_str(), cat);
+			if (!rapidDownload->search(searchres, searchname.c_str(), cat)) {
+				return false;
+			}
 			if (!searchres.empty()) {
 				return true;
 			}
-			httpDownload->search(searchres, searchname.c_str(), cat);
+			if (!httpDownload->search(searchres, searchname.c_str(), cat)) {
+				return false;
+			}
 			if (!searchres.empty()) {
 				return true;
 			}


### PR DESCRIPTION
- If gzfile ends by encountering error in the middle, make sure to fail the overall reading operation.
- If version.gz file is not parsable, delete it so it will be redownloaded next time, regardles when was the last update.
- Propagate errors down from functions, and exit early in case of errors.