### PR TITLE
Implement parallel file IO for streamerless download

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/lib/libgit2"]
 	path = src/lib/libgit2
 	url = https://github.com/libgit2/libgit2.git
+[submodule "src/lib/readerwriterqueue"]
+	path = src/lib/readerwriterqueue
+	url = https://github.com/cameron314/readerwriterqueue.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,8 +20,9 @@ add_library(Downloader STATIC
 	Downloader/Rapid/RapidDownloader.cpp
 	Downloader/Rapid/Repo.cpp
 	Downloader/Rapid/Sdp.cpp
-	Downloader/Http/HttpDownloader.cpp
 	Downloader/Http/DownloadData.cpp
+	Downloader/Http/HttpDownloader.cpp
+	Downloader/Http/IOThreadPool.cpp
 	Downloader/Http/Throttler.cpp
 	Downloader/CurlWrapper.cpp
 	Downloader/Download.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(Downloader
 	pr-md5
 	pr-sha1
 	${archiveslib}
+	readerwriterqueue
 )
 
 if(PRD_ARCHIVE_SUPPORT)

--- a/src/Downloader/Http/DownloadData.cpp
+++ b/src/Downloader/Http/DownloadData.cpp
@@ -6,8 +6,9 @@
 #include "Downloader/IDownloader.h"
 #include "Logger.h"
 
-DownloadData::DownloadData() :
-	curlw(new CurlWrapper())
+DownloadData::DownloadData(std::optional<IOThreadPool::Handle> handle) :
+	curlw(new CurlWrapper()),
+	thread_handle(std::move(handle))
 {
 }
 

--- a/src/Downloader/Http/DownloadData.h
+++ b/src/Downloader/Http/DownloadData.h
@@ -7,6 +7,9 @@
 #include <vector>
 #include <string>
 #include <chrono>
+#include <optional>
+
+#include "IOThreadPool.h"
 
 class Mirror;
 class IDownload;
@@ -24,7 +27,7 @@ public:
 class DownloadData
 {
 public:
-	DownloadData();
+	DownloadData(std::optional<IOThreadPool::Handle> handle);
 	std::unique_ptr<CurlWrapper> curlw; // curl_easy_handle
 	std::string mirror;     // mirror used
 	IDownload* download;
@@ -34,6 +37,10 @@ public:
 	std::chrono::seconds retry_after_from_server{0};
 	std::chrono::steady_clock::time_point next_retry;
 	bool force_discard = false;
+	std::optional<IOThreadPool::Handle> thread_handle;
+	bool transfer_done = false;
+	bool io_failure = false;  // Used by IO threads
+	bool *abort_download = nullptr;
 
 	void updateProgress(double total, double done);
 };

--- a/src/Downloader/Http/DownloadData.h
+++ b/src/Downloader/Http/DownloadData.h
@@ -38,7 +38,6 @@ public:
 	std::chrono::steady_clock::time_point next_retry;
 	bool force_discard = false;
 	std::optional<IOThreadPool::Handle> thread_handle;
-	bool transfer_done = false;
 	bool io_failure = false;  // Used by IO threads
 	bool *abort_download = nullptr;
 

--- a/src/Downloader/Http/IOThreadPool.cpp
+++ b/src/Downloader/Http/IOThreadPool.cpp
@@ -1,0 +1,81 @@
+#include <cassert>
+#include <random>
+#include <thread>
+#include <variant>
+
+#include "IOThreadPool.h"
+
+IOThreadPool::IOThreadPool(unsigned poolSize, unsigned workQueueSlots)
+ : randomGen(std::random_device{}()), threadDist(0, poolSize - 1)
+{
+	assert(poolSize > 0);
+	assert(workQueueSlots > 0);
+	threads.reserve(poolSize);
+	// sendQ and recvQ are not accessed under mutex, the vector can't resize.
+	sendQ.reserve(poolSize);
+	recvQ.reserve(poolSize);
+	for (unsigned id = 0; id < poolSize; ++id) {
+		sendQ.emplace_back(workQueueSlots);
+		recvQ.emplace_back(workQueueSlots);
+		threads.emplace_back(&IOThreadPool::worker, this, id);
+	}
+}
+
+IOThreadPool::~IOThreadPool()
+{
+	if (!threads.empty()) {
+		finish();
+	}
+}
+
+void IOThreadPool::pullResults()
+{
+	for (auto& r: recvQ) {
+		std::variant<Close, RetF> res;
+		while (r.try_dequeue(res)) {
+			assert(std::holds_alternative<RetF>(res));
+			std::get<RetF>(res)();
+		}
+	}
+}
+
+void IOThreadPool::finish()
+{
+	assert(!threads.empty());
+	for (auto& s: sendQ) {
+		s.wait_enqueue(Close{});
+	}
+	for (auto& r: recvQ) {
+		while (true) {
+			std::variant<Close, RetF> res;
+			r.wait_dequeue(res);
+			if (auto* f = std::get_if<RetF>(&res)) {
+				(*f)();
+			} else {
+				break;
+			}
+		}
+	}
+	for (auto& t: threads) {
+		t.join();
+	}
+	threads.clear();
+}
+
+void IOThreadPool::worker(unsigned id)
+{
+	auto& send = sendQ[id];
+	auto& recv = recvQ[id];
+	while (true) {
+		std::variant<Close, WorkF> work;
+		send.wait_dequeue(work);
+		if (auto* f = std::get_if<WorkF>(&work)) {
+			if (auto res = (*f)()) {
+				recv.enqueue(std::move(res.value()));
+			}
+		} else {
+			recv.enqueue(Close{});
+			return;
+		}
+	}
+}

--- a/src/Downloader/Http/IOThreadPool.h
+++ b/src/Downloader/Http/IOThreadPool.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <optional>
+#include <random>
+#include <string>
+#include <thread>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <readerwritercircularbuffer.h>
+#include <readerwriterqueue.h>
+
+// Thread pool. Interface to queue work and evaluate results is not thread safe,
+// all work needs to be submitted from a single thread.
+class IOThreadPool {
+public:
+	using RetF = std::function<void()>;
+	using OptRetF = std::optional<RetF>;
+	using WorkF = std::function<OptRetF()>;
+
+	class Handle {
+		constexpr explicit Handle(unsigned id) : threadId{id} {}
+		const unsigned threadId;
+		friend IOThreadPool;
+	};
+
+	// Creates a new thread pool with poolSize threads. Each thread has
+	// a constant size work queue with workQueueSlots items available.
+	IOThreadPool(unsigned poolSize, unsigned workQueueSlots);
+	~IOThreadPool();
+
+	// Executes functions returned from the finished submitted work.
+	void pullResults();
+
+	// Pulls all remaining results and closes threads. Automatically called
+	// by destructor. All other function calls on thread pool after call to
+	// finish have undefined behavior.
+	void finish();
+
+	// Submits more work to the queue. All work submitted for the same
+	// handle will execute synchronously in the FIFO order.
+	// The call blocks if the work queue is full.
+	void submit(Handle handle, WorkF&& work) {
+		assert(!threads.empty());
+		sendQ[handle.threadId].wait_enqueue(work);
+	}
+
+	// Creates a new work queue handle. Provides functionality analogous to
+	// strand in asio/Networking TS.
+	Handle getHandle() {
+		assert(!threads.empty());
+		return Handle(threadDist(randomGen));
+	}
+private:
+	struct Close {};
+
+	void worker(unsigned id);
+
+	std::vector<std::thread> threads;
+	std::vector<moodycamel::BlockingReaderWriterCircularBuffer<std::variant<Close, WorkF>>> sendQ;
+	std::vector<moodycamel::BlockingReaderWriterQueue<std::variant<Close, RetF>>> recvQ;
+	std::default_random_engine randomGen;
+	std::uniform_int_distribution<> threadDist;
+};

--- a/src/FileSystem/File.cpp
+++ b/src/FileSystem/File.cpp
@@ -15,9 +15,9 @@ CFile::~CFile()
 	Close();
 }
 
-void CFile::Close(bool discard)
+bool CFile::Close(bool discard)
 {
-	if (handle == nullptr) return;
+	if (handle == nullptr) return true;
 
 	LOG_DEBUG("closing %s%s", filename.c_str(), discard ? ", with discard" : "");
 
@@ -26,13 +26,13 @@ void CFile::Close(bool discard)
 
 	if (discard) {
 		fileSystem->removeFile(tmpfile);
-		return;
+		return true;
 	}	
 	// delete possible existing destination file
-	if (fileSystem->fileExists(filename)) {
-		fileSystem->removeFile(filename);
+	if (fileSystem->fileExists(filename) && !fileSystem->removeFile(filename)) {
+		return false;
 	}
-	fileSystem->Rename(tmpfile, filename);
+	return fileSystem->Rename(tmpfile, filename);
 }
 
 bool CFile::Open(const std::string& filename)

--- a/src/FileSystem/File.h
+++ b/src/FileSystem/File.h
@@ -20,7 +20,7 @@ public:
 	* close file. If discard is set, removes the file as something is wrong
 	* with its contents.
 	*/
-	void Close(bool discard = false);
+	bool Close(bool discard = false);
 	/**
 	* write bufsize bytes to the file.
 	*/

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -16,3 +16,4 @@ if (NOT Libgit2_FOUND AND RAPIDTOOLS)
 
 	add_subdirectory(libgit2 EXCLUDE_FROM_ALL)
 endif ()
+add_subdirectory(readerwriterqueue)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(IOThreadPoolTest)
 	}
 	for (size_t i = 0; i < queue.size(); ++i) {
 		int val = queue[i];
-		pool.submit(handlers[val], [&counters, &total_ret_counter, val] () -> IOThreadPool::OptRetF {
+		handlers[val].submit([&counters, &total_ret_counter, val] () -> IOThreadPool::OptRetF {
 			counters[val] += 1;
 			if (val % modRetEval == 0) {
 				return [&total_ret_counter] () {


### PR DESCRIPTION
The main goal is to improve download performance on Windows as there is a lot of overhead when creating
many small files caused by antivirus software.

It improves download of `byar:test` on my internet connection:
- Linux: ~18.5s -> ~13.5s
- Windows: ~50s -> ~22s

~I still have some profiling and tuning to do to see what is the bottleneck on Windows and if we can make it as performant as on Linux, but I would like to submit this bulk of code already for the review.~

Tested some simple ideas, but not much gained. Overall even when I drop File IO altogether, Windows still takes ~18s, so looks like curl itself is less optimized for that platform.

---
#### Implementation

100% of file operations and hashing of content to verify that file content is correct is moved to a dedicated thread pool. Each file belongs to a single random thread. Tasks on the thread pool are only accessing the file object, hash object, and io failure flag. File operation errors are communicated asynchronously back to the main thread that will then cancel the download.