### PR TITLE
Fix accepting of unicode arguments by pr-downloade binary

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -118,4 +118,29 @@ std::string ws2s(const std::wstring& s)
 	return r;
 }
 
+void ensureUtf8Argv(int *argc, char*** argv)
+{
+	static std::vector<std::string> argv_strings;
+	static std::vector<const char*> argv_data;
+	static int win32_argc = 0;
+	if (win32_argc == 0) {
+		wchar_t** argv_w = CommandLineToArgvW(GetCommandLineW(), &win32_argc);
+		argv_strings.reserve(win32_argc);
+		argv_data.reserve(win32_argc);
+		for (int i = 0; i < win32_argc; ++i) {
+			argv_strings.emplace_back(ws2s(argv_w[i]));
+			argv_data.emplace_back(argv_strings.back().c_str());
+		}
+		LocalFree(argv_w);
+	}
+	*argc = win32_argc;
+	*argv = const_cast<char**>(argv_data.data());
+}
+
+#else
+
+void ensureUtf8Argv(int *argc, char*** argv)
+{
+}
+
 #endif

--- a/src/Util.h
+++ b/src/Util.h
@@ -51,4 +51,10 @@ bool urlToPath(const std::string& url, std::string& path);
 std::string ws2s(const std::wstring& s);
 std::wstring s2ws(const std::string& s);
 
+/*
+        To be called as first thing in the program, ensures that argv is utf8
+        encoded on all platforms.
+*/
+void ensureUtf8Argv(int *argc, char*** argv);
+
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,9 +9,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <string>
 #include <getopt.h>
-#include <list>
 
 // TODO: Many of these enums are not implemented.
 // e.g. RAPID_VALIDATE_DELETE, ...
@@ -109,6 +107,7 @@ bool download(DownloadEnum::Category cat, const char* name)
 
 int main(int argc, char** argv)
 {
+	ensureUtf8Argv(&argc, &argv);
 	show_version();
 	if (argc < 2)
 		show_help(argv[0]);


### PR DESCRIPTION
On Windows the regular argv is encoded in a very basic non-unicode codepage. This change properly reads them as unicode strings instead and encodes them as utf-8 into argv.

Fixes #16

(Making the PR as WIP for now as I want to test a bit more)