### PR TITLE
Concurrent fetching of updates and assets

### DIFF
--- a/src/Downloader/CurlWrapper.h
+++ b/src/Downloader/CurlWrapper.h
@@ -16,6 +16,7 @@ public:
 	static std::string EscapeUrl(const std::string& url);
 	static void InitCurl();
 	static void KillCurl();
+	static CURLM* GetMultiHandle();
 	void AddHeader(const std::string& header);
 private:
 

--- a/src/Downloader/Download.cpp
+++ b/src/Downloader/Download.cpp
@@ -9,12 +9,12 @@
 #include <list>
 #include <stdio.h>
 
-IDownload::IDownload(const std::string& name, const std::string& origin_name,
-		     DownloadEnum::Category cat, download_type typ)
-    : cat(cat)
-    , dltype(typ)
-    , name(name)
-    , origin_name(origin_name)
+IDownload::IDownload(std::string name_, std::string origin_name_,
+                     DownloadEnum::Category cat_, download_type typ_)
+    : cat(cat_)
+    , dltype(typ_)
+    , name(std::move(name_))
+    , origin_name(std::move(origin_name_))
 {
 }
 

--- a/src/Downloader/Download.h
+++ b/src/Downloader/Download.h
@@ -24,7 +24,7 @@ public:
 	enum download_type { TYP_RAPID,
 			     TYP_HTTP } dltype;
 
-	IDownload(const std::string& filename = "", const std::string& orig_name = "",
+	IDownload(std::string filename = "", std::string orig_name = "",
 		  DownloadEnum::Category cat = DownloadEnum::CAT_NONE,
 		  download_type typ = TYP_HTTP);
 	/**

--- a/src/Downloader/Http/HttpDownloader.cpp
+++ b/src/Downloader/Http/HttpDownloader.cpp
@@ -594,9 +594,7 @@ bool CHttpDownloader::download(std::list<IDownload*>& download,
 
 	// Perform actual download using the Curl multi interface.
 	HTTPStats stats;
-	CURLM* curlm = curl_multi_init();
-	curl_multi_setopt(curlm, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
-	curl_multi_setopt(curlm, CURLMOPT_MAX_TOTAL_CONNECTIONS, 5);
+	CURLM* curlm = CurlWrapper::GetMultiHandle();
 
 	std::vector<DownloadData*> to_retry;
 	auto queue_comparator = [](DownloadData* a, DownloadData* b) {
@@ -678,6 +676,5 @@ abort:
 			data->curlw = nullptr;
 		}
 	}
-	curl_multi_cleanup(curlm);
 	return !aborted;
 }

--- a/src/Downloader/Http/HttpDownloader.cpp
+++ b/src/Downloader/Http/HttpDownloader.cpp
@@ -202,17 +202,25 @@ bool CHttpDownloader::ParseResult(const std::string& /*name*/,
 }
 
 bool CHttpDownloader::search(std::list<IDownload*>& res,
-			     const std::string& name,
-			     DownloadEnum::Category cat)
+                             const std::vector<DownloadSearchItem*>& items)
 {
-	LOG_DEBUG("%s", name.c_str());
-	std::string dlres;
-	const std::string url = getRequestUrl(name, cat);
-	if (!DownloadUrl(url, dlres)) {
-		LOG_ERROR("Error downloading %s %s", url.c_str(), dlres.c_str());
-		return false;
+	for (auto& item: items) {
+		if (item->found) {
+			continue;
+		}
+		LOG_DEBUG("%s", item->name.c_str());
+		std::string dlres;
+		const std::string url = getRequestUrl(item->name, item->category);
+		if (!DownloadUrl(url, dlres)) {
+			LOG_ERROR("Error downloading %s %s", url.c_str(), dlres.c_str());
+			return false;
+		}
+		if (!ParseResult(item->name, dlres, res)) {
+			return false;
+		}
+		item->found = true;
 	}
-	return ParseResult(name, dlres, res);
+	return true;
 }
 
 template<class F>

--- a/src/Downloader/Http/HttpDownloader.h
+++ b/src/Downloader/Http/HttpDownloader.h
@@ -16,8 +16,8 @@ class DownloadData;
 class CHttpDownloader : public IDownloader
 {
 public:
-	virtual bool search(std::list<IDownload*>& result, const std::string& name,
-			    DownloadEnum::Category = DownloadEnum::CAT_NONE) override;
+	virtual bool search(std::list<IDownload*>& result,
+	                    const std::vector<DownloadSearchItem*>& items) override;
 	virtual bool download(std::list<IDownload*>& download,
 			      int max_parallel = 10) override;
 	static bool DownloadUrl(const std::string& url, std::string& res);

--- a/src/Downloader/IDownloader.h
+++ b/src/Downloader/IDownloader.h
@@ -4,10 +4,12 @@
 #define I_DOWNLOADER_H
 
 #include "Download.h"
+#include "pr-downloader.h"
 
+#include <cstdio>
 #include <list>
 #include <string>
-#include <stdio.h>
+#include <vector>
 
 typedef void (*IDownloaderProcessUpdateListener)(int done, int size);
 
@@ -55,8 +57,8 @@ public:
   *	@see freeResult
   */
 	virtual bool
-	search(std::list<IDownload*>& result, const std::string& name = "",
-	       const DownloadEnum::Category = DownloadEnum::CAT_NONE) = 0;
+	search(std::list<IDownload*>& result,
+	       const std::vector<DownloadSearchItem*>& items) = 0;
 
 	/**
   *	free's a result list

--- a/src/Downloader/Rapid/RapidDownloader.cpp
+++ b/src/Downloader/Rapid/RapidDownloader.cpp
@@ -145,9 +145,6 @@ bool CRapidDownloader::setOption(const std::string& key,
 		reposgzurl = value;
 		return true;
 	}
-	if (key == "forceupdate") {
-		return true;
-	}
 	return IDownloader::setOption(key, value);
 }
 

--- a/src/Downloader/Rapid/RapidDownloader.h
+++ b/src/Downloader/Rapid/RapidDownloader.h
@@ -42,14 +42,9 @@ public:
   */
 private:
 	/**
-          lists all tags on all servers
-  */
-	void list_tag();
-	/**
           remove a dsp from the list of remote dsps
   */
-	void downloadRepo(const std::string& url);
-	bool updateRepos(const std::string& searchstr);
+	bool updateRepos(const std::vector<std::string>& searchstrs);
 	bool parse();
 	bool UpdateReposGZ();
 	std::string path;

--- a/src/Downloader/Rapid/RapidDownloader.h
+++ b/src/Downloader/Rapid/RapidDownloader.h
@@ -59,8 +59,7 @@ private:
 	/**
           download by name, for example "Complete Annihilation revision 1234"
   */
-	bool download_name(IDownload* download, int reccounter = 0,
-			   std::string name = "");
+	bool download_name(IDownload* download);
 	/**
           update all repos from the web
   */

--- a/src/Downloader/Rapid/RapidDownloader.h
+++ b/src/Downloader/Rapid/RapidDownloader.h
@@ -32,7 +32,7 @@ public:
 	/**
           start a download
   */
-	bool download(IDownload* download, int max_parallel = 10) override;
+	bool download(std::list<IDownload*>& downloads, int max_parallel = 10) override;
 
 	bool setOption(const std::string& key, const std::string& value) override;
 
@@ -54,7 +54,7 @@ private:
 	/**
           download by name, for example "Complete Annihilation revision 1234"
   */
-	bool download_name(IDownload* download);
+	bool download_name(std::list<IDownload*>& downloads);
 	/**
           update all repos from the web
   */

--- a/src/Downloader/Rapid/RapidDownloader.h
+++ b/src/Downloader/Rapid/RapidDownloader.h
@@ -27,8 +27,8 @@ public:
 	/**
           search for a mod, searches for the short + long name
   */
-	bool search(std::list<IDownload*>& result, const std::string& name,
-		    DownloadEnum::Category = DownloadEnum::CAT_NONE) override;
+	bool search(std::list<IDownload*>& result,
+	            const std::vector<DownloadSearchItem*>& items) override;
 	/**
           start a download
   */

--- a/src/Downloader/Rapid/Repo.cpp
+++ b/src/Downloader/Rapid/Repo.cpp
@@ -78,7 +78,12 @@ bool CRepo::parse()
 		}
 
 		// create new repo from url
-		rapid->addRemoteSdp(CSdp { items[0], items[1], items[3], items[2], repourl });
+		std::vector<std::string> deps;
+		if (!items[2].empty()) {
+			deps = tokenizeString(items[2], '|');
+		}
+		rapid->addRemoteSdp(CSdp(std::move(items[0]), std::move(items[1]),
+		                         std::move(items[3]), std::move(deps), repourl));
 	}
 	int errnum = Z_OK;
 	bool ok = true;

--- a/src/Downloader/Rapid/Sdp.cpp
+++ b/src/Downloader/Rapid/Sdp.cpp
@@ -32,9 +32,6 @@ CSdp::CSdp(std::string shortname_, std::string md5_, std::string name_,
 	memset(cursize_buf, 0, LENGTH_SIZE);
 	const std::string dir =
 	    fileSystem->getSpringDir() + PATH_DELIMITER + "packages" + PATH_DELIMITER;
-	if (!fileSystem->directoryExists(dir)) {
-		fileSystem->createSubdirs(dir);
-	}
 	sdpPath = dir + md5 + ".sdp";
 }
 

--- a/src/Downloader/Rapid/Sdp.cpp
+++ b/src/Downloader/Rapid/Sdp.cpp
@@ -21,14 +21,13 @@
 #include "Downloader/CurlWrapper.h"
 #include "Downloader/Download.h"
 
-CSdp::CSdp(const std::string& shortname, const std::string& md5,
-	   const std::string& name, const std::string& depends,
-	   const std::string& baseUrl)
-    : name(name)
-    , md5(md5)
-    , shortname(shortname)
-    , baseUrl(baseUrl)
-    , depends(depends)
+CSdp::CSdp(std::string shortname_, std::string md5_, std::string name_,
+           std::vector<std::string> depends_, std::string baseUrl_)
+    : name(std::move(name_))
+    , md5(std::move(md5_))
+    , shortname(std::move(shortname_))
+    , baseUrl(std::move(baseUrl_))
+    , depends(std::move(depends_))
 {
 	memset(cursize_buf, 0, LENGTH_SIZE);
 	const std::string dir =

--- a/src/Downloader/Rapid/Sdp.h
+++ b/src/Downloader/Rapid/Sdp.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "FileSystem/FileData.h"
 
@@ -17,9 +18,8 @@ class CFile;
 class CSdp
 {
 public:
-	CSdp(const std::string& shortname, const std::string& md5,
-	     const std::string& name, const std::string& depends,
-	     const std::string& baseUrl);
+	CSdp(std::string shortname, std::string md5, std::string name,
+	     std::vector<std::string> depends, std::string baseUrl);
 	CSdp(CSdp&& sdp);
 
 	~CSdp();
@@ -57,7 +57,7 @@ public:
 	/**
           returns the shortname, for example ba:stable
   */
-	const std::string& getDepends() const
+	const std::vector<std::string>& getDepends() const
 	{
 		return depends;
 	}
@@ -110,8 +110,8 @@ private:
 	std::string md5;
 	std::string shortname;
 	std::string baseUrl;
-	std::string depends;
 	std::string sdpPath;
+	std::vector<std::string> depends;
 	bool downloaded = false;
 };
 

--- a/src/Downloader/Rapid/Sdp.h
+++ b/src/Downloader/Rapid/Sdp.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_set>
 
 #include "FileSystem/FileData.h"
 
@@ -23,16 +24,8 @@ public:
 	CSdp(CSdp&& sdp);
 
 	~CSdp();
-	/**
-          download a game, we already know the host where to download from + the
-     md5 of the sdp file
-          we have to download the sdp + parse it + download associated files
-  */
-	bool download(IDownload* dl);
-	/**
-          download the sdp file if it doesn't exist yet
-  */
-	bool downloadSelf(IDownload* dl);
+
+	static bool Download(std::vector<std::pair<CSdp*, IDownload*>> const& packages);
 	/**
           returns md5 of a repo
   */
@@ -74,6 +67,17 @@ public:
 	unsigned int cursize = 0;
 
 private:
+	/* If Sdp file is downloaded and succesfully parsed returns nullptr, else
+	 * returns IDownload to download that file.
+	 */
+	std::unique_ptr<IDownload> parseOrGetDownload();
+
+	/* Marks entries from `files` list to download or not depending on whatever
+	 * there is entry is present in downloaded_md5 set.
+	 * Returns true if there are any files to download.
+	 */
+	bool filterDownloaded(std::unordered_set<std::string> const& downloaded_md5);
+
 	void parse();
 	/**
           download files streamed
@@ -104,7 +108,7 @@ private:
   */
 	bool downloadStream();
 	std::string getPoolFileUrl(const std::string& md5str) const;
-	bool downloadHTTP();
+	static bool downloadHTTP(std::vector<std::pair<CSdp*, IDownload*>> const& packages);
 
 	std::string name;
 	std::string md5;
@@ -112,7 +116,6 @@ private:
 	std::string baseUrl;
 	std::string sdpPath;
 	std::vector<std::string> depends;
-	bool downloaded = false;
 };
 
 #endif

--- a/src/FileSystem/FileSystem.h
+++ b/src/FileSystem/FileSystem.h
@@ -3,10 +3,13 @@
 #ifndef FILE_SYSTEM_H
 #define FILE_SYSTEM_H
 
-#include "FileData.h"
-
 #include <list>
 #include <string>
+#include <vector>
+#include <optional>
+
+#include "FileData.h"
+#include "HashMD5.h"
 
 class SRepository;
 class CRepo;
@@ -50,11 +53,13 @@ public:
   */
 	static bool createSubdirs(const std::string& path);
 
+	std::optional<std::vector<std::pair<std::string, HashMD5>>> getPoolFiles();
+
 	/**
           Validate all files in /pool/ (check md5)
           @return count of valid files found
   */
-	bool validatePool(const std::string& path, bool deletebroken);
+	bool validatePool(bool deletebroken);
 
 	/**
           check if file is older then secs, returns true if file is older or

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,8 +11,6 @@
 #include <unistd.h>
 #include <getopt.h>
 
-// TODO: Many of these enums are not implemented.
-// e.g. RAPID_VALIDATE_DELETE, ...
 enum {
 	RAPID_DOWNLOAD = 0,
 	RAPID_VALIDATE,
@@ -25,10 +23,9 @@ enum {
 	DOWNLOAD_GAME,
 	DOWNLOAD_ENGINE,
 	DISABLE_LOGGING,
+	DISABLE_FETCH_DEPENDS,
 	HELP,
-	SHOW_VERSION,
-	EXTRACT_FILE,
-	EXTRACT_DIRECTORY
+	SHOW_VERSION
 };
 
 static struct option long_options[] = {
@@ -43,6 +40,7 @@ static struct option long_options[] = {
     {"download-engine", 1, 0, DOWNLOAD_ENGINE},
     {"filesystem-writepath", 1, 0, FILESYSTEM_WRITEPATH},
     {"disable-logging", 0, 0, DISABLE_LOGGING},
+    {"disable-fetch-depends", 0, 0, DISABLE_FETCH_DEPENDS},
     {"help", 0, 0, HELP},
     {"version", 0, 0, SHOW_VERSION},
     {0, 0, 0, 0}};
@@ -132,6 +130,11 @@ int main(int argc, char** argv)
 			case DISABLE_LOGGING:
 				DownloadDisableLogging(true);
 				break;
+			case DISABLE_FETCH_DEPENDS: {
+				bool fetch_depends = false;
+				DownloadSetConfig(CONFIG_FETCH_DEPENDS, &fetch_depends);
+				break;
+			}
 			default:
 				break;
 		}

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -265,8 +265,8 @@ int DownloadStart()
 		return 5;
 	}
 
-	if (fetchDepends) {
-		addDepends(dls);
+	if (fetchDepends && !addDepends(dls)) {
+		return 6;
 	}
 
 	if (dls.empty()) {

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -238,7 +238,7 @@ bool addDepends(std::list<IDownload*>& dls)
 		}
 
 		std::list<IDownload*> depends_dls;
-		if (!search(depend_items, depends_dls)) {
+		if (!depend_items.empty() && !search(depend_items, depends_dls)) {
 			return false;
 		}
 		for (auto const& item: depend_items) {

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -185,9 +185,6 @@ bool DownloadSetConfig(CONFIG type, const void* value)
 		case CONFIG_FETCH_DEPENDS:
 			fetchDepends = (const bool*)value;
 			return true;
-		case CONFIG_RAPID_FORCEUPDATE:
-			rapidDownload->setOption("forceupdate", ""); // FIXME, use value
-			return true;
 	}
 	return false;
 }
@@ -201,9 +198,6 @@ bool DownloadGetConfig(CONFIG type, const void** value)
 		case CONFIG_FETCH_DEPENDS:
 			*value = (const bool*)fetchDepends;
 			return true;
-		case CONFIG_RAPID_FORCEUPDATE:
-			// FIXME: implement
-			return false;
 	}
 	return false;
 }

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -312,8 +312,7 @@ int DownloadStart()
 
 bool DownloadRapidValidate(bool deletebroken)
 {
-	const std::string path = fileSystem->getSpringDir() + PATH_DELIMITER + "pool";
-	return fileSystem->validatePool(path, deletebroken);
+	return fileSystem->validatePool(deletebroken);
 }
 
 bool DownloadDumpSDP(const char* path)

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -183,7 +183,7 @@ bool DownloadSetConfig(CONFIG type, const void* value)
 			return true;
 		}
 		case CONFIG_FETCH_DEPENDS:
-			fetchDepends = (const bool*)value;
+			fetchDepends = *static_cast<const bool*>(value);
 			return true;
 	}
 	return false;

--- a/src/pr-downloader.h
+++ b/src/pr-downloader.h
@@ -5,6 +5,10 @@
 #ifndef PR_DOWNLOADER_H
 #define PR_DOWNLOADER_H
 
+#include <vector>
+#include <string>
+#include <utility>
+
 #include "Downloader/DownloadEnum.h"
 
 #define NAME_LEN 1024
@@ -36,6 +40,20 @@ extern bool DownloadAdd(unsigned int id);
 * @see downloadSearchGetId
 */
 extern int DownloadSearch(DownloadEnum::Category category, const char* name);
+
+struct DownloadSearchItem {
+	DownloadSearchItem(DownloadEnum::Category category_, std::string name_)
+	  : name(name_), category(category_) {}
+
+	const std::string name;
+	DownloadEnum::Category category;
+	bool found = false;
+};
+
+/* Same as DownloadSearch but allows to search for multiple items in single call
+ * returns -1 on issues, else count of succesfully found items.
+*/
+extern int DownloadSearch(std::vector<DownloadSearchItem>& items);
 
 /**
 *	get info about a result / current download

--- a/src/pr-downloader.h
+++ b/src/pr-downloader.h
@@ -11,8 +11,6 @@
 struct downloadInfo
 {
 	char filename[NAME_LEN];
-	bool validated;
-	int speed;
 	DownloadEnum::Category cat;
 };
 /**
@@ -56,7 +54,6 @@ extern void DownloadShutdown();
 enum CONFIG {
 	CONFIG_FILESYSTEM_WRITEPATH = 1, // const char, sets the output directory
 	CONFIG_FETCH_DEPENDS,		 // bool, automaticly fetch depending files
-	CONFIG_RAPID_FORCEUPDATE,	// bool, always fetch repo files
 };
 
 /**


### PR DESCRIPTION
A bigger set of changes:
- Allows to fetch multiple assets concurrently
- Implements fetching of version.gz files of repos concurrently
- Searching for packages concurrently
- Downloading of packages and games in streamerless mode concurrently
- Overall fixes package dependency resolution that was just broken
- Fixes #24
- Adds support for computing test coverage from functional tests
- Optimizes computing missing set of files in sdp archive by doing less syscalls
- Reuse HTTPs connections across HTTP downloader invocations

Missing:
- Add more functional tests for new functionality