### PR TITLE
process "--disable-logging" parameter first

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,14 +104,14 @@ try {
 	} else if (args.count("version")) {
 		return 0;
 	}
+	if (args.count("disable-logging")) {
+		DownloadDisableLogging(true);
+	}
 	if (args.count("filesystem-writepath")) {
 		DownloadSetConfig(CONFIG_FILESYSTEM_WRITEPATH,
 		                  args.at("filesystem-writepath").back().c_str());
 	} else {
 		DownloadSetConfig(CONFIG_FILESYSTEM_WRITEPATH, "");
-	}
-	if (args.count("disable-logging")) {
-		DownloadDisableLogging(true);
 	}
 	if (args.count("disable-fetch-depends")) {
 		bool fetch_depends = false;


### PR DESCRIPTION
Otherwise the --filesystem-writepath parameter processing code is immune to --disable-logging and produces logs such as:

    [Info] /spring/tools/pr-downloader/src/FileSystem/FileSystem.cpp:201:setWritePath():Using filesystem-writepath: ...
    [Info] /spring/tools/pr-downloader/src/pr-downloader.cpp:185:DownloadSetConfig():Free disk space: ...