### PR TITLE
bugfix for linking libpthread

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ target_include_directories(pr-downloader
 
 set_source_files_properties(Version.cpp PROPERTIES COMPILE_DEFINITIONS "PR_DOWNLOADER_VERSION=${PR_DOWNLOADER_VERSION}")
 
+find_package (Threads)
+
 target_link_libraries(pr-downloader
     PUBLIC
         prd::jsoncpp
@@ -50,7 +52,7 @@ target_link_libraries(pr-downloader
         pr-sha1
         7zip
         readerwriterqueue
-        pthread
+        ${CMAKE_THREAD_LIBS_INIT}
 )
 
 add_executable(pr-downloader_cli main.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(pr-downloader
         pr-sha1
         7zip
         readerwriterqueue
+        pthread
 )
 
 add_executable(pr-downloader_cli main.cpp)


### PR DESCRIPTION
when pthread is not specified in cmake file, below error will occur when building
```
[ 60%] Linking CXX executable pr-downloader
/usr/bin/ld: libpr-downloader.a(IOThreadPool.cpp.o): undefined reference to symbol 'sem_destroy@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```