### PR TITLE
feat: add missing include that fixes support for gcc13 builds

### DIFF
--- a/src/Downloader/CurlWrapper.cpp
+++ b/src/Downloader/CurlWrapper.cpp
@@ -1,6 +1,7 @@
 /* This file is part of pr-downloader (GPL v2 or later), see the LICENSE file */
 
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <curl/curl.h>
 

--- a/src/Downloader/Http/ETag.cpp
+++ b/src/Downloader/Http/ETag.cpp
@@ -1,5 +1,6 @@
 #include "ETag.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <optional>

--- a/src/FileSystem/File.cpp
+++ b/src/FileSystem/File.cpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cerrno>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/FileSystem/FileSystem.cpp
+++ b/src/FileSystem/FileSystem.cpp
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <filesystem>
 #include <limits>

--- a/src/FileSystem/FileSystem.h
+++ b/src/FileSystem/FileSystem.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <optional>
 #include <string>


### PR DESCRIPTION
xref: https://gcc.gnu.org/gcc-13/porting_to.html