### PR TITLE
Support for C++ 20 compilation

### DIFF
--- a/src/Downloader/Http/HttpDownloader.cpp
+++ b/src/Downloader/Http/HttpDownloader.cpp
@@ -419,8 +419,9 @@ static void writeMd5SumFile(DownloadData* data)
 	}
 
 	std::stringstream outBuf;
+	const auto filename = std::filesystem::u8path(data->download->name).filename().u8string();
 	outBuf << data->download->hash->toString() << "  "
-		   << std::filesystem::u8path(data->download->name).filename().u8string() << "\n";
+		   << std::string(filename.cbegin(), filename.cend()) << "\n";
 	const std::string outBufStr = outBuf.str();
 
 	for (std::size_t pos = 0; pos < outBufStr.size();) {

--- a/src/FileSystem/FileSystem.cpp
+++ b/src/FileSystem/FileSystem.cpp
@@ -402,7 +402,8 @@ try {
 			LOG_WARN("Invalid file name, ignoring: %s", p.u8string().c_str());
 			continue;
 		}
-		files.emplace_back(p.u8string(), md5);
+		const auto path = p.u8string();
+		files.emplace_back(std::string(path.cbegin(), path.cend()), md5);
 	}
 	return files;
 } catch (std::filesystem::filesystem_error const& ex) {


### PR DESCRIPTION
C++ 20 introduces a std::u8string type which is not implicitly coercable to a std::string. Calls to std::filesystem::path::u8string() are thus no longer compatible with the std::string type.

This change forces an explicit cast from std::u8string to std::string in C++ 20 compilations. In C++ 17 compilations, the cast is from std::string to std::string (a noop).

Prompted by looking into integrating https://github.com/hanickadot/compile-time-regular-expressions into spring (which forces dependents to C++20 compilation unless told not to), https://github.com/beyond-all-reason/spring/issues/1181.