### PR TITLE
PR-Downloader: Add support for building for ARM on linux and MacOS

### DIFF
--- a/src/Downloader/DownloadEnum.h
+++ b/src/Downloader/DownloadEnum.h
@@ -15,9 +15,11 @@ enum Category {
 	CAT_ENGINE,  // is translated to the category which fits best, see below
 	CAT_ENGINE_LINUX,
 	CAT_ENGINE_LINUX64,
+	CAT_ENGINE_LINUX_ARM64,
 	CAT_ENGINE_WINDOWS,
 	CAT_ENGINE_WINDOWS64,
 	CAT_ENGINE_MACOSX,
+	CAT_ENGINE_MACOSX_ARM64,
 	CAT_HTTP,
 	CAT_COUNT
 };

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -32,6 +32,10 @@ const char* platformToString(Platform platform)
 			return "linux64";
 		case Platform::Windows_x64:
 			return "windows64";
+		case Platform::MacOS_arm64:
+			return "macos_arm64";
+		case Platform::Linux_arm64:
+			return "linux_arm64";
 		default:
 			// unreachable
 			std::abort();

--- a/src/Version.h
+++ b/src/Version.h
@@ -8,12 +8,18 @@ const char* getAgent();
 enum class Platform {
 	Windows_x64,
 	Linux_x64,
+	Linux_arm64,
+	MacOS_arm64
 };
 
 #if defined(_WIN64)
 constexpr Platform PRD_CURRENT_PLATFORM = Platform::Windows_x64;
 #elif defined(__linux__) && defined(__x86_64__)
 constexpr Platform PRD_CURRENT_PLATFORM = Platform::Linux_x64;
+#elif defined(__linux__) && defined(__aarch64__)
+constexpr Platform PRD_CURRENT_PLATFORM = Platform::Linux_arm64;
+#elif defined(__APPLE__) && defined(__aarch64__)
+constexpr Platform PRD_CURRENT_PLATFORM = Platform::MacOS_arm64;
 #endif
 
 const char* platformToString(Platform Platform);

--- a/src/Version.h
+++ b/src/Version.h
@@ -5,12 +5,7 @@
 const char* getVersion();
 const char* getAgent();
 
-enum class Platform {
-	Windows_x64,
-	Linux_x64,
-	Linux_arm64,
-	MacOS_arm64
-};
+enum class Platform { Windows_x64, Linux_x64, Linux_arm64, MacOS_arm64 };
 
 #if defined(_WIN64)
 constexpr Platform PRD_CURRENT_PLATFORM = Platform::Windows_x64;

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -39,6 +39,10 @@ DownloadEnum::Category getPlatformEngineCat()
 			return DownloadEnum::CAT_ENGINE_LINUX64;
 		case Platform::Windows_x64:
 			return DownloadEnum::CAT_ENGINE_WINDOWS64;
+		case Platform::Linux_arm64:
+			return DownloadEnum::CAT_ENGINE_LINUX_ARM64;
+		case Platform::MacOS_arm64:
+			return DownloadEnum::CAT_ENGINE_MACOSX_ARM64;
 		default:
 			// unreachable
 			std::abort();


### PR DESCRIPTION
This PR improves pr-downloader to build on MacOS on Apple Silicon. It should also now build on ARM linux.
I'm aware there is a *lot* of work to get the engine running on Mac.

Baby steps.