### PR TITLE
fix: suppress false positive gcc warning for 7zip

### DIFF
--- a/src/lib/7z/CMakeLists.txt
+++ b/src/lib/7z/CMakeLists.txt
@@ -57,3 +57,9 @@ target_include_directories(7zip
 )
 
 set_target_properties(7zip PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# GCC -Wstringop-overflow can't prove the bound on Bcj2Enc.c's temp[8] copy loop
+# and reports a bogus overflow; silence it on this vendored 7-Zip code.
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(7zip PRIVATE -Wno-stringop-overflow)
+endif()


### PR DESCRIPTION
When cleaning up warnings in recoil engine, this was firing. 

Specifically reproduced by `docker-build-v2/build.sh --arch arm64 linux -DCMAKE_BUILD_TYPE=RELEASE` in the engine repo.

compiler warning:
```
[1299/2952] Building C object tools/pr-downloader/src/lib/7z/CMakeFiles/7zip.dir/Bcj2Enc.c.o
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c: In function 'Bcj2Enc_Encode':
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
In file included from /build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:17:
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 8 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 9 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 10 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 11 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 12 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 13 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2Enc.c:307:18: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
  307 |       p->temp[i] = src[i];
      |       ~~~~~~~~~~~^~~~~~~~
/build/src/tools/pr-downloader/src/lib/7z/Bcj2.h:124:8: note: at offset 14 into destination object 'temp' of size 8
  124 |   Byte temp[4 * 2];
      |        ^~~~
```