### PR TITLE
Removing package flag

### DIFF
--- a/src/Downloader/Rapid/RapidDownloader.cpp
+++ b/src/Downloader/Rapid/RapidDownloader.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cctype>
 #include <filesystem>
 #include <list>
 #include <set>
@@ -104,6 +105,15 @@ static std::string ensureRapidUri(std::string_view name)
 	return "rapid://" + std::string(name);
 }
 
+static bool isMD5(std::string_view str)
+{
+	if (str.size() != 32) {
+		return false;
+	}
+	return std::all_of(str.begin(), str.end(),
+	                   [](unsigned char c) { return std::isxdigit(c); });
+}
+
 bool CRapidDownloader::search(std::list<IDownload*>& result,
                               const std::vector<DownloadSearchItem*>& items)
 {
@@ -183,30 +193,19 @@ bool CRapidDownloader::uninstall(const std::string& name)
 {
 	const std::string stripped = stripRapidUri(name);
 
-	if (!updateRepos({stripped})) {
-		return false;
-	}
-	sdps.sort(list_compare);
-
 	const std::string packages_dir =
 		fileSystem->getSpringDir() + PATH_DELIMITER + "packages" + PATH_DELIMITER;
 
-	bool any_removed = false;
-	for (const CSdp& sdp : sdps) {
-		if (!match_download_name(sdp.getShortName(), stripped) &&
-		    !match_download_name(sdp.getName(), stripped)) {
-			continue;
-		}
-
-		const std::string sdp_path = packages_dir + sdp.getMD5() + ".sdp";
+	auto uninstallSdp = [&](const std::string& sdp_md5, const std::string& display_name) {
+		const std::string sdp_path = packages_dir + sdp_md5 + ".sdp";
 		if (!fileSystem->fileExists(sdp_path)) {
-			continue;
+			return false;
 		}
 
 		// Parse the target SDP to get its pool file MD5s
 		std::vector<FileData> target_files;
 		if (!fileSystem->parseSdp(sdp_path, target_files)) {
-			LOG_ERROR("Failed to parse SDP for '%s'", sdp.getName().c_str());
+			LOG_ERROR("Failed to parse SDP for '%s'", display_name.c_str());
 			return false;
 		}
 
@@ -254,8 +253,89 @@ bool CRapidDownloader::uninstall(const std::string& name)
 		}
 
 		fileSystem->removeFile(sdp_path);
-		LOG_INFO("Uninstalled '%s'", sdp.getName().c_str());
-		any_removed = true;
+		LOG_INFO("Uninstalled '%s'", display_name.c_str());
+		return true;
+	};
+
+	if (isMD5(stripped)) {
+		if (uninstallSdp(stripped, stripped)) {
+			return true;
+		}
+		LOG_ERROR("Package '%s' is not installed", name.c_str());
+		return false;
+	}
+
+	bool any_removed = false;
+	if (updateRepos({stripped})) {
+		sdps.sort(list_compare);
+		for (const CSdp& sdp : sdps) {
+			if (!match_download_name(sdp.getShortName(), stripped) &&
+			    !match_download_name(sdp.getName(), stripped)) {
+				continue;
+			}
+			any_removed = uninstallSdp(sdp.getMD5(), sdp.getName()) || any_removed;
+		}
+	} else {
+		LOG_WARN("Failed to update rapid repos, trying local package cache");
+	}
+
+	if (!any_removed) {
+		const std::string rapid_dir =
+			fileSystem->getSpringDir() + PATH_DELIMITER + "rapid" + PATH_DELIMITER;
+		try {
+			if (fileSystem->directoryExists(rapid_dir)) {
+				for (const auto& entry :
+				     std::filesystem::recursive_directory_iterator(u8ToPath(rapid_dir))) {
+					const auto& path = entry.path();
+					if (!entry.is_regular_file() ||
+					    path.filename() != std::filesystem::path("versions.gz")) {
+						continue;
+					}
+
+					FILE* f = fileSystem->propen(pathToU8(path), "rb");
+					if (f == nullptr) {
+						continue;
+					}
+					int fd = fileSystem->dupFileFD(f);
+					if (fd < 0) {
+						fclose(f);
+						continue;
+					}
+					gzFile fp = gzdopen(fd, "rb");
+					if (fp == Z_NULL) {
+						fclose(f);
+						continue;
+					}
+
+					char buf[IO_BUF_SIZE];
+					while ((gzgets(fp, buf, sizeof(buf))) != Z_NULL) {
+						for (unsigned int i = 0; i < sizeof(buf); i++) {
+							if (buf[i] == '\n') {
+								buf[i] = 0;
+								break;
+							}
+						}
+
+						const std::string line = buf;
+						std::vector<std::string> items = tokenizeString(line, ',');
+						if (items.size() < 4) {
+							continue;
+						}
+						if (!match_download_name(items[0], stripped) &&
+						    !match_download_name(items[3], stripped)) {
+							continue;
+						}
+						any_removed =
+							uninstallSdp(items[1], items[3]) || any_removed;
+					}
+					gzclose(fp);
+					fclose(f);
+				}
+			}
+		} catch (const std::filesystem::filesystem_error& ex) {
+			LOG_ERROR("Failed to scan rapid cache: %s", ex.what());
+			return false;
+		}
 	}
 
 	if (!any_removed) {

--- a/src/Downloader/Rapid/RapidDownloader.cpp
+++ b/src/Downloader/Rapid/RapidDownloader.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <list>
 #include <set>
 #include <string>
@@ -176,6 +177,93 @@ bool CRapidDownloader::match_download_name(const std::string& str1, const std::s
 	      }
   #endif
   */
+}
+
+bool CRapidDownloader::uninstall(const std::string& name)
+{
+	const std::string stripped = stripRapidUri(name);
+
+	if (!updateRepos({stripped})) {
+		return false;
+	}
+	sdps.sort(list_compare);
+
+	const std::string packages_dir =
+		fileSystem->getSpringDir() + PATH_DELIMITER + "packages" + PATH_DELIMITER;
+
+	bool any_removed = false;
+	for (const CSdp& sdp : sdps) {
+		if (!match_download_name(sdp.getShortName(), stripped) &&
+		    !match_download_name(sdp.getName(), stripped)) {
+			continue;
+		}
+
+		const std::string sdp_path = packages_dir + sdp.getMD5() + ".sdp";
+		if (!fileSystem->fileExists(sdp_path)) {
+			continue;
+		}
+
+		// Parse the target SDP to get its pool file MD5s
+		std::vector<FileData> target_files;
+		if (!fileSystem->parseSdp(sdp_path, target_files)) {
+			LOG_ERROR("Failed to parse SDP for '%s'", sdp.getName().c_str());
+			return false;
+		}
+
+		std::unordered_set<std::string> target_md5s;
+		for (const FileData& fd : target_files) {
+			HashMD5 md5;
+			md5.Set(fd.md5, sizeof(fd.md5));
+			target_md5s.insert(md5.toString());
+		}
+
+		// Collect pool files still needed by all other installed SDPs
+		std::unordered_set<std::string> still_needed;
+		try {
+			for (const auto& entry :
+			     std::filesystem::directory_iterator(u8ToPath(packages_dir))) {
+				const auto& p = entry.path();
+				if (p.extension() != std::filesystem::path(".sdp"))
+					continue;
+				const std::string other = pathToU8(p);
+				if (other == sdp_path)
+					continue;
+				std::vector<FileData> other_files;
+				if (!fileSystem->parseSdp(other, other_files))
+					continue;
+				for (const FileData& fd : other_files) {
+					HashMD5 md5;
+					md5.Set(fd.md5, sizeof(fd.md5));
+					still_needed.insert(md5.toString());
+				}
+			}
+		} catch (const std::filesystem::filesystem_error& ex) {
+			LOG_ERROR("Failed to scan packages directory: %s", ex.what());
+			return false;
+		}
+
+		// Remove pool files that are no longer referenced by any other package
+		for (const std::string& md5 : target_md5s) {
+			if (still_needed.count(md5))
+				continue;
+			const std::string pool_file = fileSystem->getPoolFilename(md5);
+			if (fileSystem->fileExists(pool_file)) {
+				LOG_DEBUG("Removing pool file: %s", pool_file.c_str());
+				fileSystem->removeFile(pool_file);
+			}
+		}
+
+		fileSystem->removeFile(sdp_path);
+		LOG_INFO("Uninstalled '%s'", sdp.getName().c_str());
+		any_removed = true;
+	}
+
+	if (!any_removed) {
+		LOG_ERROR("Package '%s' is not installed", name.c_str());
+		return false;
+	}
+
+	return true;
 }
 
 bool CRapidDownloader::setOption(const std::string& key, const std::string& value)

--- a/src/Downloader/Rapid/RapidDownloader.h
+++ b/src/Downloader/Rapid/RapidDownloader.h
@@ -35,6 +35,11 @@ public:
 
 	bool setOption(const std::string& key, const std::string& value) override;
 
+	/**
+	 * uninstall a package by short name or descriptive name
+	 */
+	bool uninstall(const std::string& name);
+
 	void addRemoteSdp(CSdp&& dsp);
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ void show_version()
 	LOG("pr-downloader %s (%s)\n", getVersion(), platformToString(PRD_CURRENT_PLATFORM));
 }
 
-const static std::array<std::tuple<std::string, bool, std::string>, 13> opts_array = {{
+const static std::array<std::tuple<std::string, bool, std::string>, 14> opts_array = {{
 	{"help", false, "Print this help message"},
 	{"version", false, "Show version of pr-downloader and quit"},
 	{"filesystem-writepath", true, "Set the directory with data, defaults to current dir"},
@@ -34,6 +34,7 @@ const static std::array<std::tuple<std::string, bool, std::string>, 13> opts_arr
 	{"dump-sdp", true, "Dump contents of Sdp file, takes full path to the Sdp file"},
 	{"disable-logging", false, "Disables logging"},
 	{"disable-fetch-depends", false, "Disables downloading of dependend archives"},
+	{"uninstall", true, "Uninstall a game package by name, eg. 'Beyond All Reason test-16314-fff9e7a' or 'ba:test'"},
 }};
 
 void show_help(const char* cmd)
@@ -140,6 +141,19 @@ try {
 			LOG_ERROR("Validation of the rapid pool failed");
 			return 1;
 		}
+		return 0;
+	}
+
+	if (auto it = args.find("uninstall"); it != args.end()) {
+		DownloadInit();
+		for (const auto& pkg_name : it->second) {
+			if (!UninstallPackage(pkg_name.c_str())) {
+				LOG_ERROR("Failed to uninstall '%s'", pkg_name.c_str());
+				DownloadShutdown();
+				return 1;
+			}
+		}
+		DownloadShutdown();
 		return 0;
 	}
 

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -2,6 +2,7 @@
 #include "Downloader/Download.h"
 #include "Downloader/DownloadEnum.h"
 #include "Downloader/IDownloader.h"
+#include "Downloader/Rapid/RapidDownloader.h"
 #include "FileSystem/FileSystem.h"
 #include "Logger.h"
 #include "Tracer.h"
@@ -372,4 +373,10 @@ char* CalcHash(const char* str, int size, int type)
 void SetAbortDownloads(bool value)
 {
 	IDownloader::SetAbortDownloads(value);
+}
+
+bool UninstallPackage(const char* name)
+{
+	auto* rapid = static_cast<CRapidDownloader*>(IDownloader::GetRapidInstance());
+	return rapid->uninstall(name);
 }

--- a/src/pr-downloader.h
+++ b/src/pr-downloader.h
@@ -116,6 +116,11 @@ extern void SetDownloadListener(IDownloaderProcessUpdateListener listener);
 extern char* CalcHash(const char* str, int size, int type);
 
 /**
+ * uninstall a package by short name or descriptive name, e.g. "Beyond All Reason test-16314-fff9e7a"
+ */
+extern bool UninstallPackage(const char* name);
+
+/**
  * abort all downloads - must be called before shutting down,
  * all downloads must return before calling shutdown
  */


### PR DESCRIPTION
Closed #21 

```
bartek@DESKTOP-ICFN6U1:~/code/pr-downloader/builddir/src$ ./pr-downloader --filesystem-writepath /home/bartek/code/bar-lobby/assets --uninstall 'Beyond All Reason test-30484-7185ea5'
pr-downloader tarball (linux64)
[Info] /home/bartek/code/pr-downloader/src/FileSystem/FileSystem.cpp:203:setWritePath():Using filesystem-writepath: /home/bartek/code/bar-lobby/assets
[Info] /home/bartek/code/pr-downloader/src/pr-downloader.cpp:203:DownloadSetConfig():Free disk space: 930934 MB
[Info] /home/bartek/code/pr-downloader/src/Downloader/CurlWrapper.cpp:32:DumpVersion():libcurl 8.5.0 OpenSSL/3.0.13
[Info] /home/bartek/code/pr-downloader/src/Downloader/CurlWrapper.cpp:80:ConfigureCertificates():CURLOPT_CAINFO is /etc/ssl/certs/ca-certificates.crt (can be overriden by PRD_SSL_CERT_FILE env variable)
[Info] /home/bartek/code/pr-downloader/src/Downloader/CurlWrapper.cpp:82:ConfigureCertificates():CURLOPT_CAPATH is /etc/ssl/certs (can be overriden by PRD_SSL_CERT_DIR env variable)
[Info] /home/bartek/code/pr-downloader/src/Downloader/Rapid/RapidDownloader.cpp:422:ParseFD():Found 50 repos in /home/bartek/code/bar-lobby/assets/rapid/repos.springrts.com/repos.gz
[Info] /home/bartek/code/pr-downloader/src/Downloader/Http/HttpDownloader.cpp:727:download():Download: num files: 50, protocol: HTTP/1.1, to first byte: [max: 175.000ms 95%: 137.921ms median: 33.412ms mean: 46.048ms], transfer: [max: 256.426ms 95%: 238.235ms median: 70.011ms mean: 97.927ms], num retried errors: 0
[Info] /home/bartek/code/pr-downloader/src/Downloader/Rapid/RapidDownloader.cpp:256:operator()():Uninstalled 'Beyond All Reason test-30484-7185ea5'
```