### PR TITLE
Add --uninstall for removing installed games

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(pr-downloader
     FileSystem/HashGzip.cpp
     FileSystem/HashMD5.cpp
     FileSystem/IHash.cpp
+    FileSystem/RapidStore.cpp
     FileSystem/SevenZipArchive.cpp
     FileSystem/ZipArchive.cpp
     Logger.cpp

--- a/src/Downloader/Rapid/RapidDownloader.cpp
+++ b/src/Downloader/Rapid/RapidDownloader.cpp
@@ -87,14 +87,6 @@ bool CRapidDownloader::download_name(std::list<IDownload*>& downloads)
 	return ok;
 }
 
-static std::string stripRapidUri(std::string_view name)
-{
-	if (name.find("rapid://") == 0) {
-		return std::string(name.substr(8));
-	};
-	return std::string(name);
-}
-
 static std::string ensureRapidUri(std::string_view name)
 {
 	if (name.find("rapid://") == 0) {

--- a/src/FileSystem/FileSystem.cpp
+++ b/src/FileSystem/FileSystem.cpp
@@ -58,6 +58,46 @@ FILE* CFileSystem::propen(const std::string& filename, const std::string& mode)
 	return ret;
 }
 
+bool CFileSystem::readGzLines(const std::string& path,
+                              const std::function<bool(const std::string&)>& handler)
+{
+	FILE* f = propen(path, "rb");
+	if (f == nullptr) {
+		return false;
+	}
+	const int fd = dupFileFD(f);
+	if (fd < 0) {
+		fclose(f);
+		return false;
+	}
+	gzFile fp = gzdopen(fd, "rb");
+	if (fp == Z_NULL) {
+		LOG_ERROR("Could not gzdopen %s", path.c_str());
+		fclose(f);
+		return false;
+	}
+
+	char buf[IO_BUF_SIZE];
+	bool stopped = false;
+	while (!stopped && gzgets(fp, buf, sizeof(buf)) != Z_NULL) {
+		std::string line(buf);
+		while (!line.empty() && (line.back() == '\n' || line.back() == '\r')) {
+			line.pop_back();
+		}
+		stopped = !handler(line);
+	}
+
+	int errnum = Z_OK;
+	const char* errstr = gzerror(fp, &errnum);
+	const bool ok = stopped || errnum == Z_OK || errnum == Z_STREAM_END;
+	if (!ok) {
+		LOG_ERROR("Decompression error in %s: %d %s", path.c_str(), errnum, errstr);
+	}
+	gzclose(fp);
+	fclose(f);
+	return ok;
+}
+
 bool CFileSystem::hashFile(IHash* outHash, const std::string& path) const
 {
 	char data[IO_BUF_SIZE];

--- a/src/FileSystem/FileSystem.h
+++ b/src/FileSystem/FileSystem.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <list>
 #include <optional>
 #include <string>
@@ -56,6 +57,13 @@ public:
 	 * parses the file for a mod and creates
 	 */
 	bool parseSdp(const std::string& filename, std::vector<FileData>& files);
+
+	/**
+	 * reads a gzipped text file line by line with line endings stripped, a handler returning false
+	 * stops reading early without failing
+	 */
+	static bool readGzLines(const std::string& path,
+	                        const std::function<bool(const std::string&)>& handler);
 
 	bool hashFile(IHash* outHash, const std::string& path) const;
 

--- a/src/FileSystem/RapidStore.cpp
+++ b/src/FileSystem/RapidStore.cpp
@@ -139,6 +139,12 @@ CRapidStore::Resolution CRapidStore::resolve(const std::string& query,
 	matches.clear();
 	const std::string wanted = stripRapidUri(query);
 
+	// packages with no versions.gz entry carry no tags and no name, so an empty query would
+	// otherwise match them and remove one
+	if (wanted.empty()) {
+		return Resolution::NOT_FOUND;
+	}
+
 	if (isPackageMD5(wanted)) {
 		const std::string md5 = toLower(wanted);
 		for (const InstalledPackage& pkg : packages) {
@@ -171,7 +177,11 @@ CRapidStore::Resolution CRapidStore::resolve(const std::string& query,
 
 	if (matches.empty()) {
 		for (const InstalledPackage& pkg : packages) {
-			if (pkg.name == wanted) {
+			// repos can list one package under different names, all of them should resolve
+			const bool matched =
+				std::any_of(pkg.tags.begin(), pkg.tags.end(),
+			                [&](const RapidTag& tag) { return tag.name == wanted; });
+			if (matched) {
 				matches.push_back(&pkg);
 			}
 		}
@@ -211,15 +221,19 @@ try {
 
 	std::unordered_set<std::string> still_needed;
 	for (const auto& entry : std::filesystem::directory_iterator(u8ToPath(packages_dir))) {
-		// .sdp.incomplete belongs to a download in flight, its pool files are not orphans
 		const std::string ext = pathToU8(entry.path().extension());
-		if (!entry.is_regular_file() || (ext != ".sdp" && ext != ".incomplete")) {
+		// .sdp.incomplete belongs to a download in flight, its pool files are not orphans
+		const bool is_sdp = ext == ".sdp";
+		const bool is_partial_sdp =
+			ext == ".incomplete" && pathToU8(entry.path().stem().extension()) == ".sdp";
+		if (!entry.is_regular_file() || (!is_sdp && !is_partial_sdp)) {
 			continue;
 		}
+		// Anything unreadable here is already broken, so it gets skipped rather than blocking the
+		// cleanup forever. Whatever it needed comes back on the next download.
 		if (!collectPoolFiles(pathToU8(entry.path()), still_needed)) {
-			LOG_ERROR("Could not read %s, skipping pool cleanup to avoid deleting files it needs",
-			          pathToU8(entry.path().filename()).c_str());
-			return false;
+			LOG_WARN("Could not read %s, pool files only it referenced will be removed",
+			         pathToU8(entry.path().filename()).c_str());
 		}
 	}
 

--- a/src/FileSystem/RapidStore.cpp
+++ b/src/FileSystem/RapidStore.cpp
@@ -1,0 +1,292 @@
+/* This file is part of pr-downloader (GPL v2 or later), see the LICENSE file */
+
+#include "RapidStore.h"
+#include "FileData.h"
+#include "FileSystem.h"
+#include "HashMD5.h"
+#include "Logger.h"
+#include "Tracer.h"
+#include "Util.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace
+{
+
+const std::string SPRINGRTS_DOMAIN = "repos.springrts.com";
+const std::string SDP_EXT = ".sdp";
+const std::string INCOMPLETE_EXT = ".sdp.incomplete";
+
+std::string packagesDir()
+{
+	return fileSystem->getSpringDir() + PATH_DELIMITER + "packages";
+}
+
+std::string toLower(std::string str)
+{
+	std::transform(str.begin(), str.end(), str.begin(),
+	               [](unsigned char c) { return std::tolower(c); });
+	return str;
+}
+
+bool endsWith(const std::string& str, const std::string& suffix)
+{
+	return str.size() >= suffix.size() &&
+	       str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+bool isPackageMD5(const std::string& str)
+{
+	return str.size() == 32 && std::all_of(str.begin(), str.end(),
+	                                       [](unsigned char c) { return std::isxdigit(c) != 0; });
+}
+
+bool collectPoolFiles(const std::string& sdp_path, std::unordered_set<std::string>& out)
+{
+	std::vector<FileData> files;
+	if (!fileSystem->parseSdp(sdp_path, files)) {
+		return false;
+	}
+	HashMD5 md5;
+	for (const FileData& fd : files) {
+		md5.Set(fd.md5, sizeof(fd.md5));
+		out.insert(md5.toString());
+	}
+	return true;
+}
+
+}  // namespace
+
+const std::string& InstalledPackage::getName() const
+{
+	static const std::string empty;
+	return tags.empty() ? empty : tags.front().name;
+}
+
+std::size_t CRapidStore::rankDomain(const std::string& domain) const
+{
+	const auto it = std::find(domain_order.begin(), domain_order.end(), domain);
+
+	return it == domain_order.end() ? domain_order.size() : it - domain_order.begin();
+}
+
+bool CRapidStore::scanPackagesDir()
+try {
+	const auto dir = u8ToPath(packagesDir());
+	if (!std::filesystem::exists(dir)) {
+		return true;
+	}
+	for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+		if (!entry.is_regular_file() ||
+		    entry.path().extension() != std::filesystem::path(SDP_EXT)) {
+			continue;
+		}
+		const std::string md5 = toLower(pathToU8(entry.path().stem()));
+		if (!isPackageMD5(md5)) {
+			LOG_WARN("Ignoring unexpected file in packages dir: %s",
+			         pathToU8(entry.path().filename()).c_str());
+			continue;
+		}
+		packages.push_back({md5, {}});
+	}
+
+	return true;
+} catch (const std::filesystem::filesystem_error& ex) {
+	LOG_ERROR("Failed to read installed packages: %s", ex.what());
+	return false;
+}
+
+bool CRapidStore::scanVersionsCache()
+try {
+	const auto dir = u8ToPath(fileSystem->getSpringDir() + PATH_DELIMITER + "rapid");
+	if (!std::filesystem::exists(dir)) {
+		return true;
+	}
+
+	std::unordered_map<std::string, InstalledPackage*> by_md5;
+	for (InstalledPackage& pkg : packages) {
+		by_md5[pkg.md5] = &pkg;
+	}
+
+	for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+		if (!entry.is_regular_file() ||
+		    entry.path().filename() != std::filesystem::path("versions.gz")) {
+			continue;
+		}
+		// pr-downloader lays these out as rapid/<domain>/<repo>/versions.gz, which is also what
+		// the engine assumes when it ranks tag resolution by domain.
+		const std::string repo = pathToU8(entry.path().parent_path().filename());
+		const std::string domain = pathToU8(entry.path().parent_path().parent_path().filename());
+		const std::size_t rank = rankDomain(domain);
+
+		CFileSystem::readGzLines(pathToU8(entry.path()), [&](const std::string& line) {
+			const std::vector<std::string> items = tokenizeString(line, ',');
+			if (items.size() < 4) {
+				return true;
+			}
+			const auto it = by_md5.find(toLower(items[1]));
+			if (it != by_md5.end()) {
+				it->second->tags.push_back({domain, repo, items[0], items[3], rank});
+			}
+			return true;
+		});
+	}
+
+	for (InstalledPackage& pkg : packages) {
+		std::stable_sort(pkg.tags.begin(), pkg.tags.end(),
+		                 [](const RapidTag& a, const RapidTag& b) { return a.rank < b.rank; });
+	}
+
+	return true;
+} catch (const std::filesystem::filesystem_error& ex) {
+	LOG_ERROR("Failed to read the rapid cache: %s", ex.what());
+	return false;
+}
+
+bool CRapidStore::scan()
+{
+	TRACE();
+	packages.clear();
+
+	domain_order.clear();
+	if (const auto order = getEnvVar("PRD_RAPID_TAG_RESOLUTION_ORDER"); order.has_value()) {
+		for (const std::string& domain : tokenizeString(*order, ';')) {
+			if (!domain.empty()) {
+				domain_order.push_back(domain);
+			}
+		}
+	}
+	if (std::find(domain_order.begin(), domain_order.end(), SPRINGRTS_DOMAIN) ==
+	    domain_order.end()) {
+		domain_order.push_back(SPRINGRTS_DOMAIN);
+	}
+
+	return scanPackagesDir() && scanVersionsCache();
+}
+
+CRapidStore::Resolution CRapidStore::resolve(const std::string& query,
+                                             std::vector<const InstalledPackage*>& matches) const
+{
+	matches.clear();
+	const std::string wanted = stripRapidUri(query);
+
+	if (isPackageMD5(wanted)) {
+		const std::string md5 = toLower(wanted);
+		for (const InstalledPackage& pkg : packages) {
+			if (pkg.md5 == md5) {
+				matches.push_back(&pkg);
+
+				return Resolution::OK;
+			}
+		}
+
+		return Resolution::NOT_FOUND;
+	}
+
+	std::size_t best_rank = domain_order.size() + 1;
+	for (const InstalledPackage& pkg : packages) {
+		for (const RapidTag& tag : pkg.tags) {
+			if (tag.tag == wanted) {
+				best_rank = std::min(best_rank, tag.rank);
+			}
+		}
+	}
+	for (const InstalledPackage& pkg : packages) {
+		const bool matched =
+			std::any_of(pkg.tags.begin(), pkg.tags.end(), [&](const RapidTag& tag) {
+				return tag.tag == wanted && tag.rank == best_rank;
+			});
+		if (matched) {
+			matches.push_back(&pkg);
+		}
+	}
+
+	if (matches.empty()) {
+		for (const InstalledPackage& pkg : packages) {
+			const bool matched =
+				std::any_of(pkg.tags.begin(), pkg.tags.end(),
+			                [&](const RapidTag& tag) { return tag.name == wanted; });
+			if (matched) {
+				matches.push_back(&pkg);
+			}
+		}
+	}
+
+	if (matches.empty()) {
+		return Resolution::NOT_FOUND;
+	}
+
+	return matches.size() == 1 ? Resolution::OK : Resolution::AMBIGUOUS;
+}
+
+bool CRapidStore::remove(const std::vector<const InstalledPackage*>& to_remove)
+try {
+	TRACE();
+	const std::string packages_dir = packagesDir();
+
+	std::unordered_set<std::string> orphan_candidates;
+	bool ok = true;
+	for (const InstalledPackage* pkg : to_remove) {
+		const std::string sdp_path = packages_dir + PATH_DELIMITER + pkg->md5 + SDP_EXT;
+		if (!collectPoolFiles(sdp_path, orphan_candidates)) {
+			LOG_WARN("Could not read %s, its pool files are left in place", sdp_path.c_str());
+		}
+		// The sdp goes first so that an interrupted removal leaves an uninstalled package rather
+		// than an installed one with files missing underneath it.
+		if (!CFileSystem::removeFile(sdp_path)) {
+			ok = false;
+			continue;
+		}
+		LOG_INFO("Uninstalled %s%s%s", pkg->md5.c_str(), pkg->getName().empty() ? "" : " ",
+		         pkg->getName().c_str());
+	}
+
+	if (orphan_candidates.empty()) {
+		return ok;
+	}
+
+	std::unordered_set<std::string> still_needed;
+	for (const auto& entry : std::filesystem::directory_iterator(u8ToPath(packages_dir))) {
+		const std::string filename = pathToU8(entry.path().filename());
+		if (!entry.is_regular_file() ||
+		    (!endsWith(filename, SDP_EXT) && !endsWith(filename, INCOMPLETE_EXT))) {
+			continue;
+		}
+		if (!collectPoolFiles(pathToU8(entry.path()), still_needed)) {
+			LOG_ERROR("Could not read %s, skipping pool cleanup to avoid deleting files it needs",
+			          filename.c_str());
+			return false;
+		}
+	}
+
+	std::unordered_set<std::string> touched_dirs;
+	for (const std::string& md5 : orphan_candidates) {
+		if (still_needed.count(md5) > 0) {
+			continue;
+		}
+		const std::string pool_file = fileSystem->getPoolFilename(md5);
+		if (!CFileSystem::fileExists(pool_file)) {
+			continue;
+		}
+		if (CFileSystem::removeFile(pool_file)) {
+			touched_dirs.insert(CFileSystem::DirName(pool_file));
+		} else {
+			ok = false;
+		}
+	}
+
+	for (const std::string& dir : touched_dirs) {
+		if (std::filesystem::is_empty(u8ToPath(dir))) {
+			CFileSystem::removeDir(dir);
+		}
+	}
+
+	return ok;
+} catch (const std::filesystem::filesystem_error& ex) {
+	LOG_ERROR("Failed to clean up the pool: %s", ex.what());
+	return false;
+}

--- a/src/FileSystem/RapidStore.cpp
+++ b/src/FileSystem/RapidStore.cpp
@@ -95,6 +95,7 @@ try {
 		by_md5[pkg.md5] = &pkg;
 	}
 
+	bool index_complete = true;
 	const auto rapid_dir = u8ToPath(fileSystem->getSpringDir() + PATH_DELIMITER + "rapid");
 	if (std::filesystem::exists(rapid_dir)) {
 		for (const auto& entry : std::filesystem::recursive_directory_iterator(rapid_dir)) {
@@ -107,15 +108,22 @@ try {
 			const std::size_t rank =
 				rankDomain(pathToU8(entry.path().parent_path().parent_path().filename()));
 
-			CFileSystem::readGzLines(pathToU8(entry.path()), [&](const std::string& line) {
-				const std::vector<std::string> items = tokenizeString(line, ',');
-				if (items.size() >= 4) {
-					if (const auto it = by_md5.find(toLower(items[1])); it != by_md5.end()) {
-						it->second->tags.push_back({items[0], items[3], rank});
+			const bool read =
+				CFileSystem::readGzLines(pathToU8(entry.path()), [&](const std::string& line) {
+					const std::vector<std::string> items = tokenizeString(line, ',');
+					if (items.size() >= 4) {
+						if (const auto it = by_md5.find(toLower(items[1])); it != by_md5.end()) {
+							it->second->tags.push_back({items[0], items[3], rank});
+						}
 					}
-				}
-				return true;
-			});
+					return true;
+				});
+			// Resolving against a cache we only partly read could pick a different package than
+			// the one the caller named, so the whole scan is treated as failed.
+			if (!read) {
+				LOG_ERROR("Could not read %s", pathToU8(entry.path()).c_str());
+				index_complete = false;
+			}
 		}
 	}
 
@@ -127,7 +135,7 @@ try {
 		}
 	}
 
-	return true;
+	return index_complete;
 } catch (const std::filesystem::filesystem_error& ex) {
 	LOG_ERROR("Failed to read installed packages: %s", ex.what());
 	return false;

--- a/src/FileSystem/RapidStore.cpp
+++ b/src/FileSystem/RapidStore.cpp
@@ -17,10 +17,6 @@
 namespace
 {
 
-const std::string SPRINGRTS_DOMAIN = "repos.springrts.com";
-const std::string SDP_EXT = ".sdp";
-const std::string INCOMPLETE_EXT = ".sdp.incomplete";
-
 std::string packagesDir()
 {
 	return fileSystem->getSpringDir() + PATH_DELIMITER + "packages";
@@ -31,12 +27,6 @@ std::string toLower(std::string str)
 	std::transform(str.begin(), str.end(), str.begin(),
 	               [](unsigned char c) { return std::tolower(c); });
 	return str;
-}
-
-bool endsWith(const std::string& str, const std::string& suffix)
-{
-	return str.size() >= suffix.size() &&
-	       str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 bool isPackageMD5(const std::string& str)
@@ -61,12 +51,6 @@ bool collectPoolFiles(const std::string& sdp_path, std::unordered_set<std::strin
 
 }  // namespace
 
-const std::string& InstalledPackage::getName() const
-{
-	static const std::string empty;
-	return tags.empty() ? empty : tags.front().name;
-}
-
 std::size_t CRapidStore::rankDomain(const std::string& domain) const
 {
 	const auto it = std::find(domain_order.begin(), domain_order.end(), domain);
@@ -74,85 +58,12 @@ std::size_t CRapidStore::rankDomain(const std::string& domain) const
 	return it == domain_order.end() ? domain_order.size() : it - domain_order.begin();
 }
 
-bool CRapidStore::scanPackagesDir()
-try {
-	const auto dir = u8ToPath(packagesDir());
-	if (!std::filesystem::exists(dir)) {
-		return true;
-	}
-	for (const auto& entry : std::filesystem::directory_iterator(dir)) {
-		if (!entry.is_regular_file() ||
-		    entry.path().extension() != std::filesystem::path(SDP_EXT)) {
-			continue;
-		}
-		const std::string md5 = toLower(pathToU8(entry.path().stem()));
-		if (!isPackageMD5(md5)) {
-			LOG_WARN("Ignoring unexpected file in packages dir: %s",
-			         pathToU8(entry.path().filename()).c_str());
-			continue;
-		}
-		packages.push_back({md5, {}});
-	}
-
-	return true;
-} catch (const std::filesystem::filesystem_error& ex) {
-	LOG_ERROR("Failed to read installed packages: %s", ex.what());
-	return false;
-}
-
-bool CRapidStore::scanVersionsCache()
-try {
-	const auto dir = u8ToPath(fileSystem->getSpringDir() + PATH_DELIMITER + "rapid");
-	if (!std::filesystem::exists(dir)) {
-		return true;
-	}
-
-	std::unordered_map<std::string, InstalledPackage*> by_md5;
-	for (InstalledPackage& pkg : packages) {
-		by_md5[pkg.md5] = &pkg;
-	}
-
-	for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
-		if (!entry.is_regular_file() ||
-		    entry.path().filename() != std::filesystem::path("versions.gz")) {
-			continue;
-		}
-		// pr-downloader lays these out as rapid/<domain>/<repo>/versions.gz, which is also what
-		// the engine assumes when it ranks tag resolution by domain.
-		const std::string repo = pathToU8(entry.path().parent_path().filename());
-		const std::string domain = pathToU8(entry.path().parent_path().parent_path().filename());
-		const std::size_t rank = rankDomain(domain);
-
-		CFileSystem::readGzLines(pathToU8(entry.path()), [&](const std::string& line) {
-			const std::vector<std::string> items = tokenizeString(line, ',');
-			if (items.size() < 4) {
-				return true;
-			}
-			const auto it = by_md5.find(toLower(items[1]));
-			if (it != by_md5.end()) {
-				it->second->tags.push_back({domain, repo, items[0], items[3], rank});
-			}
-			return true;
-		});
-	}
-
-	for (InstalledPackage& pkg : packages) {
-		std::stable_sort(pkg.tags.begin(), pkg.tags.end(),
-		                 [](const RapidTag& a, const RapidTag& b) { return a.rank < b.rank; });
-	}
-
-	return true;
-} catch (const std::filesystem::filesystem_error& ex) {
-	LOG_ERROR("Failed to read the rapid cache: %s", ex.what());
-	return false;
-}
-
 bool CRapidStore::scan()
-{
+try {
 	TRACE();
 	packages.clear();
-
 	domain_order.clear();
+
 	if (const auto order = getEnvVar("PRD_RAPID_TAG_RESOLUTION_ORDER"); order.has_value()) {
 		for (const std::string& domain : tokenizeString(*order, ';')) {
 			if (!domain.empty()) {
@@ -160,12 +71,66 @@ bool CRapidStore::scan()
 			}
 		}
 	}
-	if (std::find(domain_order.begin(), domain_order.end(), SPRINGRTS_DOMAIN) ==
+	if (std::find(domain_order.begin(), domain_order.end(), "repos.springrts.com") ==
 	    domain_order.end()) {
-		domain_order.push_back(SPRINGRTS_DOMAIN);
+		domain_order.push_back("repos.springrts.com");
 	}
 
-	return scanPackagesDir() && scanVersionsCache();
+	const auto packages_dir = u8ToPath(packagesDir());
+	if (std::filesystem::exists(packages_dir)) {
+		for (const auto& entry : std::filesystem::directory_iterator(packages_dir)) {
+			if (!entry.is_regular_file() ||
+			    entry.path().extension() != std::filesystem::path(".sdp")) {
+				continue;
+			}
+			const std::string md5 = toLower(pathToU8(entry.path().stem()));
+			if (isPackageMD5(md5)) {
+				packages.push_back({md5, "", {}});
+			}
+		}
+	}
+
+	std::unordered_map<std::string, InstalledPackage*> by_md5;
+	for (InstalledPackage& pkg : packages) {
+		by_md5[pkg.md5] = &pkg;
+	}
+
+	const auto rapid_dir = u8ToPath(fileSystem->getSpringDir() + PATH_DELIMITER + "rapid");
+	if (std::filesystem::exists(rapid_dir)) {
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(rapid_dir)) {
+			if (!entry.is_regular_file() ||
+			    entry.path().filename() != std::filesystem::path("versions.gz")) {
+				continue;
+			}
+			// These are laid out as rapid/<domain>/<repo>/versions.gz, which is also what the
+			// engine assumes when it ranks tag resolution by domain.
+			const std::size_t rank =
+				rankDomain(pathToU8(entry.path().parent_path().parent_path().filename()));
+
+			CFileSystem::readGzLines(pathToU8(entry.path()), [&](const std::string& line) {
+				const std::vector<std::string> items = tokenizeString(line, ',');
+				if (items.size() >= 4) {
+					if (const auto it = by_md5.find(toLower(items[1])); it != by_md5.end()) {
+						it->second->tags.push_back({items[0], items[3], rank});
+					}
+				}
+				return true;
+			});
+		}
+	}
+
+	for (InstalledPackage& pkg : packages) {
+		std::stable_sort(pkg.tags.begin(), pkg.tags.end(),
+		                 [](const RapidTag& a, const RapidTag& b) { return a.rank < b.rank; });
+		if (!pkg.tags.empty()) {
+			pkg.name = pkg.tags.front().name;
+		}
+	}
+
+	return true;
+} catch (const std::filesystem::filesystem_error& ex) {
+	LOG_ERROR("Failed to read installed packages: %s", ex.what());
+	return false;
 }
 
 CRapidStore::Resolution CRapidStore::resolve(const std::string& query,
@@ -190,27 +155,23 @@ CRapidStore::Resolution CRapidStore::resolve(const std::string& query,
 	std::size_t best_rank = domain_order.size() + 1;
 	for (const InstalledPackage& pkg : packages) {
 		for (const RapidTag& tag : pkg.tags) {
-			if (tag.tag == wanted) {
-				best_rank = std::min(best_rank, tag.rank);
+			if (tag.tag != wanted || tag.rank > best_rank) {
+				continue;
 			}
-		}
-	}
-	for (const InstalledPackage& pkg : packages) {
-		const bool matched =
-			std::any_of(pkg.tags.begin(), pkg.tags.end(), [&](const RapidTag& tag) {
-				return tag.tag == wanted && tag.rank == best_rank;
-			});
-		if (matched) {
-			matches.push_back(&pkg);
+			if (tag.rank < best_rank) {
+				best_rank = tag.rank;
+				matches.clear();
+			}
+			// tags of one package are contiguous, so this drops a repeated tag not a rival package
+			if (matches.empty() || matches.back() != &pkg) {
+				matches.push_back(&pkg);
+			}
 		}
 	}
 
 	if (matches.empty()) {
 		for (const InstalledPackage& pkg : packages) {
-			const bool matched =
-				std::any_of(pkg.tags.begin(), pkg.tags.end(),
-			                [&](const RapidTag& tag) { return tag.name == wanted; });
-			if (matched) {
+			if (pkg.name == wanted) {
 				matches.push_back(&pkg);
 			}
 		}
@@ -231,7 +192,7 @@ try {
 	std::unordered_set<std::string> orphan_candidates;
 	bool ok = true;
 	for (const InstalledPackage* pkg : to_remove) {
-		const std::string sdp_path = packages_dir + PATH_DELIMITER + pkg->md5 + SDP_EXT;
+		const std::string sdp_path = packages_dir + PATH_DELIMITER + pkg->md5 + ".sdp";
 		if (!collectPoolFiles(sdp_path, orphan_candidates)) {
 			LOG_WARN("Could not read %s, its pool files are left in place", sdp_path.c_str());
 		}
@@ -241,8 +202,7 @@ try {
 			ok = false;
 			continue;
 		}
-		LOG_INFO("Uninstalled %s%s%s", pkg->md5.c_str(), pkg->getName().empty() ? "" : " ",
-		         pkg->getName().c_str());
+		LOG_INFO("Uninstalled %s %s", pkg->md5.c_str(), pkg->name.c_str());
 	}
 
 	if (orphan_candidates.empty()) {
@@ -251,25 +211,22 @@ try {
 
 	std::unordered_set<std::string> still_needed;
 	for (const auto& entry : std::filesystem::directory_iterator(u8ToPath(packages_dir))) {
-		const std::string filename = pathToU8(entry.path().filename());
-		if (!entry.is_regular_file() ||
-		    (!endsWith(filename, SDP_EXT) && !endsWith(filename, INCOMPLETE_EXT))) {
+		// .sdp.incomplete belongs to a download in flight, its pool files are not orphans
+		const std::string ext = pathToU8(entry.path().extension());
+		if (!entry.is_regular_file() || (ext != ".sdp" && ext != ".incomplete")) {
 			continue;
 		}
 		if (!collectPoolFiles(pathToU8(entry.path()), still_needed)) {
 			LOG_ERROR("Could not read %s, skipping pool cleanup to avoid deleting files it needs",
-			          filename.c_str());
+			          pathToU8(entry.path().filename()).c_str());
 			return false;
 		}
 	}
 
 	std::unordered_set<std::string> touched_dirs;
 	for (const std::string& md5 : orphan_candidates) {
-		if (still_needed.count(md5) > 0) {
-			continue;
-		}
 		const std::string pool_file = fileSystem->getPoolFilename(md5);
-		if (!CFileSystem::fileExists(pool_file)) {
+		if (still_needed.count(md5) > 0 || !CFileSystem::fileExists(pool_file)) {
 			continue;
 		}
 		if (CFileSystem::removeFile(pool_file)) {

--- a/src/FileSystem/RapidStore.h
+++ b/src/FileSystem/RapidStore.h
@@ -1,0 +1,63 @@
+/* This file is part of pr-downloader (GPL v2 or later), see the LICENSE file */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+struct RapidTag {
+	std::string domain;
+	std::string repo;
+	std::string tag;
+	std::string name;
+	std::size_t rank;
+};
+
+struct InstalledPackage {
+	std::string md5;
+	std::vector<RapidTag> tags;
+
+	/**
+	 * empty when no local versions.gz mentions this package
+	 */
+	const std::string& getName() const;
+};
+
+/**
+ * Read/write access to the installed rapid packages under the write path, without any network
+ * access. Names are resolved against what is on disk rather than against a repo index, so a package
+ * stays removable after its tag stops being published.
+ */
+class CRapidStore
+{
+public:
+	enum class Resolution {
+		OK,
+		NOT_FOUND,
+		AMBIGUOUS,
+	};
+
+	bool scan();
+
+	/**
+	 * Matches an md5, a rapid tag or an archive name against the installed packages, following the
+	 * precedence the engine uses in ArchiveNameResolver. Fills matches with the single match on OK
+	 * and with every candidate on AMBIGUOUS.
+	 */
+	Resolution resolve(const std::string& query,
+	                   std::vector<const InstalledPackage*>& matches) const;
+
+	/**
+	 * Removes the sdp files and then every pool file left unreferenced by the packages that remain.
+	 */
+	bool remove(const std::vector<const InstalledPackage*>& to_remove);
+
+private:
+	std::vector<InstalledPackage> packages;
+	std::vector<std::string> domain_order;
+
+	std::size_t rankDomain(const std::string& domain) const;
+	bool scanPackagesDir();
+	bool scanVersionsCache();
+};

--- a/src/FileSystem/RapidStore.h
+++ b/src/FileSystem/RapidStore.h
@@ -7,8 +7,6 @@
 #include <vector>
 
 struct RapidTag {
-	std::string domain;
-	std::string repo;
 	std::string tag;
 	std::string name;
 	std::size_t rank;
@@ -16,18 +14,14 @@ struct RapidTag {
 
 struct InstalledPackage {
 	std::string md5;
+	std::string name;
 	std::vector<RapidTag> tags;
-
-	/**
-	 * empty when no local versions.gz mentions this package
-	 */
-	const std::string& getName() const;
 };
 
 /**
- * Read/write access to the installed rapid packages under the write path, without any network
- * access. Names are resolved against what is on disk rather than against a repo index, so a package
- * stays removable after its tag stops being published.
+ * The installed rapid packages under the write path. Names resolve against what is on disk instead
+ * of against a repo index, so removing a package needs no network and keeps working after its tag
+ * stops being published.
  */
 class CRapidStore
 {
@@ -41,15 +35,15 @@ public:
 	bool scan();
 
 	/**
-	 * Matches an md5, a rapid tag or an archive name against the installed packages, following the
-	 * precedence the engine uses in ArchiveNameResolver. Fills matches with the single match on OK
-	 * and with every candidate on AMBIGUOUS.
+	 * Matches an md5, a rapid tag or an archive name, following the precedence the engine uses in
+	 * ArchiveNameResolver. Fills matches with the one match on OK and with every candidate on
+	 * AMBIGUOUS.
 	 */
 	Resolution resolve(const std::string& query,
 	                   std::vector<const InstalledPackage*>& matches) const;
 
 	/**
-	 * Removes the sdp files and then every pool file left unreferenced by the packages that remain.
+	 * Removes the sdp files, then the pool files left unreferenced by the packages that remain.
 	 */
 	bool remove(const std::vector<const InstalledPackage*>& to_remove);
 
@@ -58,6 +52,4 @@ private:
 	std::vector<std::string> domain_order;
 
 	std::size_t rankDomain(const std::string& domain) const;
-	bool scanPackagesDir();
-	bool scanVersionsCache();
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -9,6 +9,14 @@
 #include <memory>
 #include <zlib.h>
 
+std::string stripRapidUri(std::string_view name)
+{
+	if (name.find("rapid://") == 0) {
+		return std::string(name.substr(8));
+	}
+	return std::string(name);
+}
+
 std::vector<std::string> tokenizeString(const std::string& str, char c)
 {
 	std::vector<std::string> res;

--- a/src/Util.h
+++ b/src/Util.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -24,6 +25,11 @@ std::string getUrl(const FileData* info, const std::string& path);
  * empty tokens aren't ignored
  */
 std::vector<std::string> tokenizeString(const std::string& str, char c);
+
+/**
+ * removes the rapid:// scheme so that both rapid://zk:stable and zk:stable name the same package
+ */
+std::string stripRapidUri(std::string_view name);
 
 /**
  * decompresses in to out

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ void show_version()
 	LOG("pr-downloader %s (%s)\n", getVersion(), platformToString(PRD_CURRENT_PLATFORM));
 }
 
-const static std::array<std::tuple<std::string, bool, std::string>, 13> opts_array = {{
+const static std::array<std::tuple<std::string, bool, std::string>, 14> opts_array = {{
 	{"help", false, "Print this help message"},
 	{"version", false, "Show version of pr-downloader and quit"},
 	{"filesystem-writepath", true, "Set the directory with data, defaults to current dir"},
@@ -32,6 +32,8 @@ const static std::array<std::tuple<std::string, bool, std::string>, 13> opts_arr
 	{"validate-sdp", true,
      "Validate correctness of files in Sdp archive, takes full path to the Sdp file"},
 	{"dump-sdp", true, "Dump contents of Sdp file, takes full path to the Sdp file"},
+	{"uninstall", true,
+     "Remove an installed game by md5, rapid tag or name, eg. 'gg:test', 'GG 1.2'"},
 	{"disable-logging", false, "Disables logging"},
 	{"disable-fetch-depends", false, "Disables downloading of dependend archives"},
 }};
@@ -55,6 +57,9 @@ Environment variables:
       Whatever to use streamer.cgi for downloading.
   PRD_RAPID_REPO_MASTER=[https://repos.springrts.com/repos.gz]
       URL of the rapid repo master.
+  PRD_RAPID_TAG_RESOLUTION_ORDER=[]
+      ';' separated domains, preference order when --uninstall resolves a rapid tag.
+      Mirrors the engine's RapidTagResolutionOrder, repos.springrts.com is always last.
   PRD_MAX_HTTP_REQS_PER_SEC=[0]
       Limit on number of requests per second for HTTP downloading, 0 = unlimited
   PRD_HTTP_SEARCH_URL=[https://springfiles.springrts.com/json.php]
@@ -129,6 +134,14 @@ try {
 	if (auto it = args.find("validate-sdp"); it != args.end()) {
 		if (!ValidateSDP(it->second.back().c_str())) {
 			LOG_ERROR("Error validating SDP");
+			return 1;
+		}
+		return 0;
+	}
+
+	if (auto it = args.find("uninstall"); it != args.end()) {
+		if (!UninstallPackages(it->second)) {
+			LOG_ERROR("Error uninstalling");
 			return 1;
 		}
 		return 0;

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -372,7 +372,7 @@ bool UninstallPackages(const std::vector<std::string>& names)
 				LOG_ERROR("'%s' matches %d installed packages, uninstall by md5 instead:",
 				          name.c_str(), static_cast<int>(matches.size()));
 				for (const InstalledPackage* pkg : matches) {
-					LOG_ERROR("  %s %s", pkg->md5.c_str(), pkg->getName().c_str());
+					LOG_ERROR("  %s %s", pkg->md5.c_str(), pkg->name.c_str());
 				}
 				resolved_all = false;
 				break;

--- a/src/pr-downloader.cpp
+++ b/src/pr-downloader.cpp
@@ -3,12 +3,14 @@
 #include "Downloader/DownloadEnum.h"
 #include "Downloader/IDownloader.h"
 #include "FileSystem/FileSystem.h"
+#include "FileSystem/RapidStore.h"
 #include "Logger.h"
 #include "Tracer.h"
 #include "Version.h"
 #include "lib/md5/md5.h"
 #include <base64.h>
 
+#include <algorithm>
 #include <assert.h>
 #include <cinttypes>
 #include <cstdint>
@@ -341,6 +343,46 @@ bool DownloadDumpSDP(const char* path)
 bool ValidateSDP(const char* path)
 {
 	return fileSystem->validateSDP(path);
+}
+
+bool UninstallPackages(const std::vector<std::string>& names)
+{
+	CRapidStore store;
+	if (!store.scan()) {
+		return false;
+	}
+
+	std::vector<const InstalledPackage*> to_remove;
+	bool resolved_all = true;
+	for (const std::string& name : names) {
+		std::vector<const InstalledPackage*> matches;
+		switch (store.resolve(name, matches)) {
+			case CRapidStore::Resolution::OK:
+				// two names on the same command line can point at one package
+				if (std::find(to_remove.begin(), to_remove.end(), matches.front()) ==
+				    to_remove.end()) {
+					to_remove.push_back(matches.front());
+				}
+				break;
+			case CRapidStore::Resolution::NOT_FOUND:
+				LOG_ERROR("'%s' is not installed", name.c_str());
+				resolved_all = false;
+				break;
+			case CRapidStore::Resolution::AMBIGUOUS:
+				LOG_ERROR("'%s' matches %d installed packages, uninstall by md5 instead:",
+				          name.c_str(), static_cast<int>(matches.size()));
+				for (const InstalledPackage* pkg : matches) {
+					LOG_ERROR("  %s %s", pkg->md5.c_str(), pkg->getName().c_str());
+				}
+				resolved_all = false;
+				break;
+		}
+	}
+	if (!resolved_all) {
+		return false;
+	}
+
+	return store.remove(to_remove);
 }
 
 void DownloadDisableLogging(bool disableLogging)

--- a/src/pr-downloader.h
+++ b/src/pr-downloader.h
@@ -100,6 +100,13 @@ extern bool DownloadDumpSDP(const char* path);
 extern bool ValidateSDP(const char* path);
 
 /**
+ * Removes installed rapid packages, named by md5, rapid tag or archive name. Resolves against what
+ * is on disk and never touches the network. A name that matches more than one installed package is
+ * an error, use the md5 to pick one.
+ */
+extern bool UninstallPackages(const std::vector<std::string>& names);
+
+/**
  * control printing to stdout
  */
 extern void DownloadDisableLogging(bool disableLogging);

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -922,6 +922,67 @@ class TestDownloading(unittest.TestCase):
 
         self.assertTrue(self.verify_downloaded_rapid('repo:pkg'))
 
+    def test_uninstall_empty_name_fails_and_changes_nothing(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg')
+        archive.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+
+        # Without a versions.gz the package has no tags and no name, which must
+        # not turn an empty argument into a match.
+        shutil.rmtree(os.path.join(self.dest_root, 'rapid'))
+
+        self.assertNotEqual(self.call_uninstall(''), 0)
+        self.assertNotEqual(self.call_uninstall('rapid://'), 0)
+
+        self.assertTrue(self.exists_in_dest(archive))
+
+    def test_uninstall_by_name_from_lower_ranked_domain(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg', 'Real Name')
+        archive.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+
+        # A higher ranked domain lists the same package under another name, the
+        # name the package was installed under still has to resolve.
+        self.write_rapid_domain('other.example.com', 'repo',
+                                [f'repo:other,{archive.get_md5()},,Other Name'])
+
+        self.assertEqual(
+            self.call_uninstall('Real Name',
+                                extra_env={
+                                    'PRD_RAPID_TAG_RESOLUTION_ORDER':
+                                        'other.example.com'
+                                }), 0)
+
+        self.assertFalse(self.exists_in_dest(archive))
+
+    def test_uninstall_tolerates_unreadable_incomplete_sdp(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg')
+        pool_file = archive.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+
+        # What a killed download leaves behind.
+        truncated = os.path.join(self.dest_root, 'packages',
+                                 f'{"f" * 32}.sdp.incomplete')
+        with open(truncated, 'wb') as out:
+            out.write(b'junk')
+
+        self.assertEqual(self.call_uninstall('repo:pkg'), 0)
+
+        self.assertFalse(self.exists_in_dest(archive))
+        self.assertFalse(self.exists_in_dest(pool_file))
+
     def test_uninstall_ambiguous_name_fails_and_changes_nothing(self) -> None:
         repo1 = self.rapid.add_repo('repo1')
         archive1 = repo1.add_archive('pkg', 'Same Name')

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -940,6 +940,28 @@ class TestDownloading(unittest.TestCase):
 
         self.assertTrue(self.exists_in_dest(archive))
 
+    def test_uninstall_refuses_an_unreadable_versions_cache(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg')
+        archive.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+
+        # A second domain whose cache cannot be read. The name still resolves
+        # from the good domain, but what the bad one would have said is unknown,
+        # so uninstalling has to refuse rather than act on a partial index.
+        self.write_rapid_domain('other.example.com', 'repo', [])
+        corrupt = os.path.join(self.dest_root, 'rapid', 'other.example.com',
+                               'repo', 'versions.gz')
+        with open(corrupt, 'wb') as out:
+            out.write(b'\x1f\x8b' + b'\x00' * 64)
+
+        self.assertNotEqual(self.call_uninstall('repo:pkg'), 0)
+
+        self.assertTrue(self.verify_downloaded_rapid('repo:pkg'))
+
     def test_uninstall_by_name_from_lower_ranked_domain(self) -> None:
         repo = self.rapid.add_repo('repo')
         archive = repo.add_archive('pkg', 'Real Name')

--- a/test/functional_test.py
+++ b/test/functional_test.py
@@ -405,9 +405,10 @@ class TestDownloading(unittest.TestCase):
     dest_root: str
     server: TestingHTTPServer
 
-    def call_rapid_download(self,
-                            shortnames: str | list[str],
-                            use_streamer: bool = False) -> int:
+    def call_pr_downloader(self,
+                           args: list[str],
+                           use_streamer: bool = False,
+                           extra_env: dict[str, str] = {}) -> int:
         with tempfile.NamedTemporaryFile(
                 prefix='pr-run-', delete=not self.keep_temp_files) as out:
             if self.keep_temp_files:
@@ -419,26 +420,41 @@ class TestDownloading(unittest.TestCase):
                     'true' if use_streamer else 'false',
             }
             env.update(os.environ)
+            env.update(extra_env)
             if self.coverage_profiles_path is not None:
                 env['LLVM_PROFILE_FILE'] = os.path.join(
                     self.coverage_profiles_path,
                     f'{os.path.basename(out.name)}.profraw')
 
-            if isinstance(shortnames, str):
-                shortnames = [shortnames]
-            dl_args = []
-            for sn in shortnames:
-                dl_args.extend(['--download-game', sn])
-
             res = subprocess.run([
                 self.pr_downloader_path, '--filesystem-writepath',
                 self.dest_root
-            ] + dl_args,
+            ] + args,
                                  stderr=subprocess.STDOUT,
                                  stdout=out,
                                  timeout=10,
                                  env=env)
             return res.returncode
+
+    def call_rapid_download(self,
+                            shortnames: str | list[str],
+                            use_streamer: bool = False) -> int:
+        if isinstance(shortnames, str):
+            shortnames = [shortnames]
+        dl_args = []
+        for sn in shortnames:
+            dl_args.extend(['--download-game', sn])
+        return self.call_pr_downloader(dl_args, use_streamer=use_streamer)
+
+    def call_uninstall(self,
+                       names: str | list[str],
+                       extra_env: dict[str, str] = {}) -> int:
+        if isinstance(names, str):
+            names = [names]
+        args = []
+        for n in names:
+            args.extend(['--uninstall', n])
+        return self.call_pr_downloader(args, extra_env=extra_env)
 
     def verify_downloaded_rapid(self, archive: str | Archive) -> bool:
         if isinstance(archive, str):
@@ -450,6 +466,22 @@ class TestDownloading(unittest.TestCase):
             if not os.path.exists(dest_file) or not rf.is_identical(dest_file):
                 return False
         return True
+
+    def dest_path(self, rf: RapidFile) -> str:
+        return os.path.join(self.dest_root, rf.rapid_filename())
+
+    def exists_in_dest(self, rf: RapidFile) -> bool:
+        return os.path.exists(self.dest_path(rf))
+
+    def write_rapid_domain(self, domain: str, repo: str,
+                           lines: list[str]) -> None:
+        """Adds a versions.gz to the local cache under a made up domain."""
+        path = os.path.join(self.dest_root, 'rapid', domain, repo,
+                            'versions.gz')
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        contents = ''.join(f'{line}\n' for line in lines).encode()
+        with open(path, 'wb') as out:
+            out.write(gzip.compress(contents))
 
     def clear_dest_root(self) -> None:
         for f in os.listdir(self.dest_root):
@@ -814,6 +846,140 @@ class TestDownloading(unittest.TestCase):
         with self.server.serve():
             self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
             self.assertTrue(visited_file)
+
+    def test_uninstall_removes_package_and_its_pool_files(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg')
+        a_file = archive.add_file('a.txt', b'a')
+        b_file = archive.add_file('b.txt', b'bb')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+        self.assertTrue(self.verify_downloaded_rapid('repo:pkg'))
+
+        # Every uninstall here runs outside serve(), so the server is down and
+        # resolution has to work off the local install.
+        self.assertEqual(self.call_uninstall('repo:pkg'), 0)
+
+        self.assertFalse(self.exists_in_dest(archive))
+        self.assertFalse(self.exists_in_dest(a_file))
+        self.assertFalse(self.exists_in_dest(b_file))
+
+    def test_uninstall_keeps_pool_files_other_packages_use(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive1 = repo.add_archive('pkg:1')
+        shared = archive1.add_file('a.txt', b'a')
+        only_in_1 = archive1.add_file('b.txt', b'bb')
+        archive2 = repo.add_archive('pkg:2')
+        archive2.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(
+                self.call_rapid_download(['repo:pkg:1', 'repo:pkg:2']), 0)
+
+        self.assertEqual(self.call_uninstall('repo:pkg:1'), 0)
+
+        self.assertFalse(self.exists_in_dest(archive1))
+        self.assertFalse(self.exists_in_dest(only_in_1))
+        self.assertTrue(self.exists_in_dest(archive2))
+        self.assertTrue(self.exists_in_dest(shared))
+
+    def test_uninstall_accepts_md5_name_and_uri(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        by_md5 = repo.add_archive('pkg:1')
+        by_md5.add_file('a.txt', b'a')
+        by_name = repo.add_archive('pkg:2', 'Package Two')
+        by_name.add_file('b.txt', b'bb')
+        by_uri = repo.add_archive('pkg:3')
+        by_uri.add_file('c.txt', b'ccc')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(
+                self.call_rapid_download(
+                    ['repo:pkg:1', 'repo:pkg:2', 'repo:pkg:3']), 0)
+
+        self.assertEqual(self.call_uninstall(by_md5.get_md5()), 0)
+        self.assertEqual(self.call_uninstall('Package Two'), 0)
+        self.assertEqual(self.call_uninstall('rapid://repo:pkg:3'), 0)
+
+        self.assertFalse(self.exists_in_dest(by_md5))
+        self.assertFalse(self.exists_in_dest(by_name))
+        self.assertFalse(self.exists_in_dest(by_uri))
+
+    def test_uninstall_unknown_package_fails_and_changes_nothing(self) -> None:
+        repo = self.rapid.add_repo('repo')
+        archive = repo.add_archive('pkg')
+        archive.add_file('a.txt', b'a')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(self.call_rapid_download('repo:pkg'), 0)
+
+        self.assertNotEqual(self.call_uninstall('repo:nosuchpkg'), 0)
+
+        self.assertTrue(self.verify_downloaded_rapid('repo:pkg'))
+
+    def test_uninstall_ambiguous_name_fails_and_changes_nothing(self) -> None:
+        repo1 = self.rapid.add_repo('repo1')
+        archive1 = repo1.add_archive('pkg', 'Same Name')
+        archive1.add_file('a.txt', b'a')
+        repo2 = self.rapid.add_repo('repo2')
+        archive2 = repo2.add_archive('pkg', 'Same Name')
+        archive2.add_file('b.txt', b'bb')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(
+                self.call_rapid_download(['repo1:pkg', 'repo2:pkg']), 0)
+
+        self.assertNotEqual(self.call_uninstall('Same Name'), 0)
+
+        self.assertTrue(self.verify_downloaded_rapid('repo1:pkg'))
+        self.assertTrue(self.verify_downloaded_rapid('repo2:pkg'))
+
+    def _base_two_domains_same_tag(self) -> tuple[Archive, Archive]:
+        repo = self.rapid.add_repo('repo')
+        archive1 = repo.add_archive('pkg:1')
+        archive1.add_file('a.txt', b'a')
+        archive2 = repo.add_archive('pkg:2')
+        archive2.add_file('b.txt', b'bb')
+        self.rapid.save(self.serving_root)
+
+        with self.server.serve():
+            self.assertEqual(
+                self.call_rapid_download(['repo:pkg:1', 'repo:pkg:2']), 0)
+
+        # Point a second domain at a different package under the tag that the
+        # real repo uses for archive1.
+        self.write_rapid_domain(
+            'other.example.com', 'repo',
+            [f'repo:pkg:1,{archive2.get_md5()},,Other'])
+
+        return archive1, archive2
+
+    def test_uninstall_tag_prefers_configured_domain(self) -> None:
+        archive1, archive2 = self._base_two_domains_same_tag()
+
+        self.assertEqual(
+            self.call_uninstall('repo:pkg:1',
+                                extra_env={
+                                    'PRD_RAPID_TAG_RESOLUTION_ORDER':
+                                        'other.example.com'
+                                }), 0)
+
+        self.assertTrue(self.exists_in_dest(archive1))
+        self.assertFalse(self.exists_in_dest(archive2))
+
+    def test_uninstall_tag_equal_domain_preference_fails(self) -> None:
+        archive1, archive2 = self._base_two_domains_same_tag()
+
+        self.assertNotEqual(self.call_uninstall('repo:pkg:1'), 0)
+
+        self.assertTrue(self.exists_in_dest(archive1))
+        self.assertTrue(self.exists_in_dest(archive2))
 
     # TODO(marekr): Fix bugs that are being reproduced by the tests below.
 


### PR DESCRIPTION
Fixes #21 

Adds `--uninstall`, taking an md5, a rapid tag or an archive name.

Apologies to @BElluu for the toe-stepping. I got most of the way through this before I noticed #66 was already open - I was chasing a bar-lobby issue, went looking for a way to remove a package, didn't find one, and wrote it. Should have checked the PR list first. Happy for this to be closed in favour of #66 if you'd rather carry it there, or to pull anything useful across.

The main difference is where names get resolved. Going through the repo index means uninstall needs the network and stops working once a tag is unpublished, which seems backwards for something that only touches local files - you can't remove what you never installed, and the remote can't tell you what you have. So this reads `packages/` and the local versions.gz cache, and never calls `DownloadInit`, same as `--dump-sdp` and `--rapid-validate`.

That also lets tag handling line up with the engine. As far as I can tell from RapidHandler, the engine ranks tag matches by domain through `RapidTagResolutionOrder`, so a tag published by two mirrors doesn't resolve arbitrarily; `PRD_RAPID_TAG_RESOLUTION_ORDER` does the same here. It isn't full parity - the engine also resolves a bare shortname to the newest installed version, and that reads modinfo.lua out of the archive, which pr-downloader can't do. I left that form out rather than approximate it.

A name matching more than one installed package is an error listing the candidates instead of removing all of them, since there's no undo. Same reasoning for refusing outright when a versions.gz can't be read, rather than resolving against a partial index and maybe picking the wrong package.

The sdp is unlinked before the pool sweep so an interrupted run leaves a package uninstalled rather than installed with files missing underneath it, and `.sdp.incomplete` files count as still-needed so a download in flight doesn't lose its pool.

Functional tests included since that was the ask on #66. Listing installed packages is #65's job so nothing here does that, though this would make it short. The `readGzLines` helper is new and only has one caller - Repo.cpp and RapidDownloader.cpp could move onto it, but I left them alone to keep this off the download path.

AI disclosure: written with assistance from Claude Code.
