### PR TITLE
Build standalone CLI binaries in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build CLI binaries
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x86_64
+            dockerfile: ci/Dockerfile.linux-x86_64
+          - platform: windows-x86_64
+            dockerfile: ci/Dockerfile.windows-x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          # git describe drives the version string baked into the binary, and it
+          # needs the tags, which a shallow checkout does not fetch.
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: artifacts
+          outputs: type=local,dest=dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-downloader-${{ matrix.platform }}
+          path: dist/
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - run: |
+          cd artifacts
+          for dir in */; do
+            (cd "$dir" && zip -r "../${dir%/}.zip" .)
+          done
+          gh release upload "$GITHUB_REF_NAME" ./*.zip --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,10 @@ if(UNIX)
 endif()
 if(NOT UNIX OR NOT TARGET prd::libcurl)
     find_package(CURL 7.85 REQUIRED)
-    add_library(prd::libcurl ALIAS CURL::libcurl)
+    # Not an ALIAS: curl's own CMake package makes CURL::libcurl an alias of
+    # CURL::libcurl_static or _shared, and CMake cannot alias an alias.
+    add_library(prd::libcurl INTERFACE IMPORTED)
+    target_link_libraries(prd::libcurl INTERFACE CURL::libcurl)
 endif()
 
 # ZLIB

--- a/ci/Dockerfile.linux-x86_64
+++ b/ci/Dockerfile.linux-x86_64
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Standalone linux x86_64 build of the pr-downloader CLI.
+#
+#   docker build -f ci/Dockerfile.linux-x86_64 -t prd-linux .
+#   docker build -f ci/Dockerfile.linux-x86_64 --target artifacts \
+#       --output type=local,dest=dist/linux-x86_64 .
+#
+# bookworm is the oldest Debian whose libcurl (7.88) satisfies the >=7.84
+# pkg-config check in the top level CMakeLists, and its glibc 2.36 sets the
+# floor for what the resulting binary will run on.
+FROM debian:bookworm-slim AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		binutils \
+		build-essential \
+		ca-certificates \
+		cmake \
+		git \
+		libcurl4-openssl-dev \
+		ninja-build \
+		pkg-config \
+		python3 \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# jsoncpp and minizip are deliberately not installed: without them CMake falls
+# back to the vendored copies, which keeps them out of the shared library list.
+
+# test_io_error_fails_download makes a pool file unreadable with chmod 0 and
+# expects the download to fail, which root would sail straight through.
+RUN useradd -m -u 1000 builder && mkdir -p /build /out && chown builder:builder /build /out
+
+COPY --chown=builder:builder . /src
+USER builder
+WORKDIR /src
+
+# git_util_describe silently degrades the version string to "tarball" if git
+# refuses to read the checkout.
+RUN git config --global --add safe.directory '*'
+
+ARG RUN_FUNCTIONAL_TESTS=1
+RUN SRC_DIR=/src BUILD_DIR=/build OUT_DIR=/out \
+	RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS} \
+	sh ci/build-linux.sh
+
+FROM scratch AS artifacts
+COPY --from=build /out/ /

--- a/ci/Dockerfile.windows-x86_64
+++ b/ci/Dockerfile.windows-x86_64
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Windows x86_64 build of the pr-downloader CLI, cross compiled from linux with
+# mingw-w64.
+#
+#   docker build -f ci/Dockerfile.windows-x86_64 -t prd-windows .
+#   docker build -f ci/Dockerfile.windows-x86_64 --target artifacts \
+#       --output type=local,dest=dist/windows-x86_64 .
+#
+# Base image and dependency source mirror the engine's own windows build
+# (docker-build-v2/images/amd64-windows in beyond-all-reason/RecoilEngine) so
+# the CLI is built against the same libraries the engine ships.
+FROM ubuntu:24.04 AS toolchain
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		binutils \
+		ca-certificates \
+		cmake \
+		g++-mingw-w64-x86-64-posix \
+		gcc-mingw-w64-x86-64-posix \
+		git \
+		ninja-build \
+		python3 \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth=1 https://github.com/beyond-all-reason/mingwlibs64.git /build/mingwlibs64
+ENV MINGWLIBS=/build/mingwlibs64
+
+FROM toolchain AS build
+
+# uid 1000 is taken by the stock "ubuntu" account on this base image.
+RUN useradd -m -u 1001 builder && mkdir -p /build/b /out && chown builder:builder /build/b /out
+
+COPY --chown=builder:builder . /src
+USER builder
+WORKDIR /src
+
+# git_util_describe silently degrades the version string to "tarball" if git
+# refuses to read the checkout.
+RUN git config --global --add safe.directory '*'
+
+RUN SRC_DIR=/src BUILD_DIR=/build/b OUT_DIR=/out sh ci/build-windows.sh
+
+FROM scratch AS artifacts
+COPY --from=build /out/ /

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Builds the standalone pr-downloader CLI for linux and drops the result in
+# OUT_DIR. Meant to be run inside the image built from ci/Dockerfile.linux-x86_64
+# but works on any host with the same packages installed.
+
+set -eu
+
+SRC_DIR="${SRC_DIR:-/src}"
+BUILD_DIR="${BUILD_DIR:-/build}"
+OUT_DIR="${OUT_DIR:-/out}"
+BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
+RUN_FUNCTIONAL_TESTS="${RUN_FUNCTIONAL_TESTS:-1}"
+
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" -G Ninja \
+	-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+# pr-downloader / prd::base64 / prd::jsoncpp are what the engine links against,
+# so build them by name to catch a break there even though the CLI pulls them in.
+LIB_TARGETS="pr-downloader pr-base64"
+if ninja -C "$BUILD_DIR" -t targets all 2>/dev/null | grep -q '^lib/jsoncpp/libpr-jsoncpp'; then
+	LIB_TARGETS="$LIB_TARGETS pr-jsoncpp"
+else
+	echo "note: jsoncpp came from the system, prd::jsoncpp is an imported target"
+fi
+
+cmake --build "$BUILD_DIR" --target $LIB_TARGETS pr-downloader_cli
+
+BIN="$BUILD_DIR/src/pr-downloader"
+
+echo "== $BIN --version =="
+"$BIN" --version
+echo "== $BIN --help =="
+"$BIN" --help
+echo "== ldd =="
+ldd "$BIN"
+
+if [ "$RUN_FUNCTIONAL_TESTS" = "1" ]; then
+	echo "== functional tests =="
+	python3 "$SRC_DIR/test/functional_test.py" --pr-downloader-path "$BIN"
+fi
+
+mkdir -p "$OUT_DIR"
+cp "$BIN" "$OUT_DIR/pr-downloader"
+objcopy --only-keep-debug "$OUT_DIR/pr-downloader" "$OUT_DIR/pr-downloader.debug"
+objcopy --strip-debug --strip-unneeded "$OUT_DIR/pr-downloader"
+objcopy --add-gnu-debuglink="$OUT_DIR/pr-downloader.debug" "$OUT_DIR/pr-downloader"
+
+ls -l "$OUT_DIR"

--- a/ci/build-windows.sh
+++ b/ci/build-windows.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Cross builds the standalone pr-downloader CLI for windows x86_64 and drops the
+# result, plus the runtime DLLs it needs, in OUT_DIR. Meant to be run inside the
+# image built from ci/Dockerfile.windows-x86_64.
+#
+# Nothing here runs the produced exe; that has to happen on a windows host or
+# under wine.
+
+set -eu
+
+SRC_DIR="${SRC_DIR:-/src}"
+BUILD_DIR="${BUILD_DIR:-/build}"
+OUT_DIR="${OUT_DIR:-/out}"
+BUILD_TYPE="${BUILD_TYPE:-RelWithDebInfo}"
+TOOLCHAIN_FILE="${TOOLCHAIN_FILE:-$SRC_DIR/ci/toolchain-mingw-w64-x86_64.cmake}"
+MINGWLIBS="${MINGWLIBS:?set MINGWLIBS to a mingwlibs64 checkout}"
+
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" -G Ninja \
+	-DCMAKE_TOOLCHAIN_FILE="$TOOLCHAIN_FILE" \
+	-DMINGWLIBS="$MINGWLIBS" \
+	-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+
+# jsoncpp and minizip always come from the vendored copies here: the system
+# lookups for both are gated on UNIX in the top level CMakeLists.
+cmake --build "$BUILD_DIR" --target \
+	pr-downloader pr-base64 pr-jsoncpp pr-downloader_cli
+
+BIN="$BUILD_DIR/src/pr-downloader.exe"
+
+mkdir -p "$OUT_DIR"
+cp "$BIN" "$OUT_DIR/pr-downloader.exe"
+x86_64-w64-mingw32-objcopy --only-keep-debug "$OUT_DIR/pr-downloader.exe" "$OUT_DIR/pr-downloader.exe.debug"
+x86_64-w64-mingw32-objcopy --strip-debug --strip-unneeded "$OUT_DIR/pr-downloader.exe"
+x86_64-w64-mingw32-objcopy --add-gnu-debuglink="$OUT_DIR/pr-downloader.exe.debug" "$OUT_DIR/pr-downloader.exe"
+
+# mingwlibs64 ships shared libraries only, so the exe is not self contained.
+# Walk the import tables until nothing new turns up, since the DLLs pull in each
+# other as well.
+pending="$OUT_DIR/pr-downloader.exe"
+while [ -n "$pending" ]; do
+	next=""
+	for f in $pending; do
+		for dll in $(x86_64-w64-mingw32-objdump -p "$f" | sed -n 's/.*DLL Name: //p'); do
+			if [ -f "$MINGWLIBS/dll/$dll" ] && [ ! -f "$OUT_DIR/$dll" ]; then
+				cp "$MINGWLIBS/dll/$dll" "$OUT_DIR/$dll"
+				next="$next $OUT_DIR/$dll"
+			fi
+		done
+	done
+	pending="$next"
+done
+
+echo "== bundled runtime =="
+ls -l "$OUT_DIR"

--- a/ci/mingwlibs64.cmake
+++ b/ci/mingwlibs64.cmake
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Points dependency lookup at a mingwlibs64 checkout. Mirrors the windows branch
+# of the engine's top level CMakeLists (beyond-all-reason/RecoilEngine), which
+# pr-downloader does not do for itself because inside the engine build it
+# inherits all of this from the parent scope.
+
+if(NOT MINGWLIBS AND DEFINED ENV{MINGWLIBS})
+    set(MINGWLIBS $ENV{MINGWLIBS} CACHE PATH "Location of the mingwlibs64 package")
+endif()
+
+if(NOT EXISTS "${MINGWLIBS}" OR NOT IS_DIRECTORY "${MINGWLIBS}")
+    message(FATAL_ERROR "MINGWLIBS '${MINGWLIBS}' is not a valid directory")
+endif()
+
+# mingwlibs64 ships DLLs with no accompanying import libraries, which CMake
+# refuses to consider as link targets by default since 3.17.
+# https://discourse.cmake.org/t/findzlib-fails-starting-with-cmake-3-17/6046/4
+list(PREPEND CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
+
+set(CMAKE_PREFIX_PATH ${MINGWLIBS})
+set(CMAKE_LIBRARY_PATH ${MINGWLIBS}/dll ${MINGWLIBS}/lib)
+set(CMAKE_FIND_ROOT_PATH ${MINGWLIBS} ${CMAKE_FIND_ROOT_PATH})
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/ci/toolchain-mingw-w64-x86_64.cmake
+++ b/ci/toolchain-mingw-w64-x86_64.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Cross compile to windows x86_64 with mingw-w64. Mirrors the engine's toolchain
+# file (docker-build-v2/images/amd64-windows/toolchain.cmake in
+# beyond-all-reason/RecoilEngine), which covers the compiler only.
+#
+# Dependency resolution lives in mingwlibs64.cmake, pulled in after project()
+# because some of what it sets gets overwritten by CMake's platform modules if
+# set here.
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+# The -posix suffixed drivers select the winpthreads threading model, which is
+# what makes libstdc++ ship working std::thread / std::mutex.
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc-posix)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++-posix)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+set(CMAKE_DLLTOOL x86_64-w64-mingw32-dlltool)
+
+set(CMAKE_C_FLAGS_INIT "-static-libstdc++ -static-libgcc")
+set(CMAKE_CXX_FLAGS_INIT "-static-libstdc++ -static-libgcc")
+
+set(CMAKE_PROJECT_pr-downloader_INCLUDE "${CMAKE_CURRENT_LIST_DIR}/mingwlibs64.cmake")


### PR DESCRIPTION
The new lobby currently downloads a whole engine release just to get a pr-downloader binary out of it, then uses that to fetch everything else. Publishing prd binaries directly removes that detour, and bundling one into the lobby's own release removes the live dependency entirely.

prd::libcurl is a trap rather than a live bug - nothing we build today reaches that line, since mingwlibs64 ships no CMake package for curl and linux goes through pkg-config. Worth changing anyway so whoever moves the windows deps to vcpkg doesn't lose an afternoon to it. The engine's windows configure produces an identical build file with and without it.

I ran the windows binary and the functional tests by hand on windows, since a linux runner can't execute it. MSVC is untested, and I configured the engine against this branch without compiling it.

AI disclosure: written with assistance from Claude Code.
